### PR TITLE
Add dynamic run names to GitVibe workflows

### DIFF
--- a/.github/workflows/address-feedback.yml
+++ b/.github/workflows/address-feedback.yml
@@ -1,4 +1,5 @@
 name: GitVibe address feedback
+run-name: "[git-vibe][address-feedback]: PR #${{ inputs.pr-number }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,4 +1,5 @@
 name: GitVibe develop
+run-name: "[git-vibe][develop]: Issue #${{ inputs.issue-number }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -1,4 +1,5 @@
 name: GitVibe investigate
+run-name: "[git-vibe][investigate]: Issue #${{ inputs.issue-number }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/materialize.yml
+++ b/.github/workflows/materialize.yml
@@ -1,4 +1,5 @@
 name: GitVibe materialize
+run-name: "[git-vibe][materialize]: Discussion #${{ inputs.discussion-number }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -1,4 +1,5 @@
 name: GitVibe summarize
+run-name: "[git-vibe][summarize]: Discussion #${{ inputs.discussion-number }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,5 @@
 name: GitVibe validate
+run-name: "[git-vibe][validate]: ${{ inputs.discussion-number != '' && format('Discussion #{0}', inputs.discussion-number) || inputs.issue-number != '' && format('Issue #{0}', inputs.issue-number) || 'Artifact' }}"
 
 on:
   workflow_dispatch:

--- a/examples/consumer/.github/workflows/address-feedback.yml
+++ b/examples/consumer/.github/workflows/address-feedback.yml
@@ -1,4 +1,5 @@
 name: GitVibe address feedback
+run-name: "[git-vibe][address-feedback]: PR #${{ inputs.pr-number }}"
 
 on:
   workflow_dispatch:

--- a/examples/consumer/.github/workflows/develop.yml
+++ b/examples/consumer/.github/workflows/develop.yml
@@ -1,4 +1,5 @@
 name: GitVibe develop
+run-name: "[git-vibe][develop]: Issue #${{ inputs.issue-number }}"
 
 on:
   workflow_dispatch:

--- a/examples/consumer/.github/workflows/investigate.yml
+++ b/examples/consumer/.github/workflows/investigate.yml
@@ -1,4 +1,5 @@
 name: GitVibe investigate
+run-name: "[git-vibe][investigate]: Issue #${{ inputs.issue-number }}"
 
 on:
   workflow_dispatch:

--- a/examples/consumer/.github/workflows/materialize.yml
+++ b/examples/consumer/.github/workflows/materialize.yml
@@ -1,4 +1,5 @@
 name: GitVibe materialize
+run-name: "[git-vibe][materialize]: Discussion #${{ inputs.discussion-number }}"
 
 on:
   workflow_dispatch:

--- a/examples/consumer/.github/workflows/summarize.yml
+++ b/examples/consumer/.github/workflows/summarize.yml
@@ -1,4 +1,5 @@
 name: GitVibe summarize
+run-name: "[git-vibe][summarize]: Discussion #${{ inputs.discussion-number }}"
 
 on:
   workflow_dispatch:

--- a/examples/consumer/.github/workflows/validate.yml
+++ b/examples/consumer/.github/workflows/validate.yml
@@ -1,4 +1,5 @@
 name: GitVibe validate
+run-name: "[git-vibe][validate]: ${{ inputs.discussion-number != '' && format('Discussion #{0}', inputs.discussion-number) || inputs.issue-number != '' && format('Issue #{0}', inputs.issue-number) || 'Artifact' }}"
 
 on:
   workflow_dispatch:

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -4,7 +4,7 @@ import { parse } from "yaml";
 
 /**
  * @typedef {{ default?: unknown, required?: boolean, type?: string }} WorkflowInput
- * @typedef {{ env?: Record<string, string>, inputs?: Record<string, WorkflowInput>, jobs?: Record<string, WorkflowJob>, on?: { push?: { paths?: string[] }, workflow_call?: { inputs?: Record<string, WorkflowInput>, secrets?: Record<string, { required?: boolean }> }, workflow_dispatch?: { inputs?: Record<string, WorkflowInput> } } }} Workflow
+ * @typedef {{ env?: Record<string, string>, inputs?: Record<string, WorkflowInput>, jobs?: Record<string, WorkflowJob>, name?: string, on?: { push?: { paths?: string[] }, workflow_call?: { inputs?: Record<string, WorkflowInput>, secrets?: Record<string, { required?: boolean }> }, workflow_dispatch?: { inputs?: Record<string, WorkflowInput> } }, ["run-name"]?: string }} Workflow
  * @typedef {{ env?: Record<string, string>, if?: string, needs?: string, outputs?: Record<string, string>, permissions?: Record<string, string>, secrets?: Record<string, string>, steps?: WorkflowStep[], ["timeout-minutes"]?: string, uses?: string }} WorkflowJob
  * @typedef {{ env?: Record<string, string>, id?: string, if?: string, name?: string, uses?: string, with?: Record<string, unknown> }} WorkflowStep
  * @typedef {{ env: Record<string, string>, name?: string, uses?: string }} SimulatedStep
@@ -42,6 +42,90 @@ const actionFiles = [
   "summarize/action.yml",
   "validate/action.yml",
 ];
+
+const workflowRunNameSpecs = [
+  { file: ".github/workflows/validate.yml", stage: "validate", multiArtifact: true },
+  { file: ".github/workflows/summarize.yml", stage: "summarize", artifact: "Discussion" },
+  { file: ".github/workflows/materialize.yml", stage: "materialize", artifact: "Discussion" },
+  { file: ".github/workflows/investigate.yml", stage: "investigate", artifact: "Issue" },
+  { file: ".github/workflows/develop.yml", stage: "develop", artifact: "Issue" },
+  { file: ".github/workflows/address-feedback.yml", stage: "address-feedback", artifact: "PR" },
+  {
+    file: "examples/consumer/.github/workflows/validate.yml",
+    stage: "validate",
+    multiArtifact: true,
+  },
+  {
+    file: "examples/consumer/.github/workflows/summarize.yml",
+    stage: "summarize",
+    artifact: "Discussion",
+  },
+  {
+    file: "examples/consumer/.github/workflows/materialize.yml",
+    stage: "materialize",
+    artifact: "Discussion",
+  },
+  {
+    file: "examples/consumer/.github/workflows/investigate.yml",
+    stage: "investigate",
+    artifact: "Issue",
+  },
+  { file: "examples/consumer/.github/workflows/develop.yml", stage: "develop", artifact: "Issue" },
+  {
+    file: "examples/consumer/.github/workflows/address-feedback.yml",
+    stage: "address-feedback",
+    artifact: "PR",
+  },
+];
+
+const workflowStaticNames = {
+  ".github/workflows/validate.yml": "GitVibe validate",
+  ".github/workflows/summarize.yml": "GitVibe summarize",
+  ".github/workflows/materialize.yml": "GitVibe materialize",
+  ".github/workflows/investigate.yml": "GitVibe investigate",
+  ".github/workflows/develop.yml": "GitVibe develop",
+  ".github/workflows/address-feedback.yml": "GitVibe address feedback",
+  "examples/consumer/.github/workflows/validate.yml": "GitVibe validate",
+  "examples/consumer/.github/workflows/summarize.yml": "GitVibe summarize",
+  "examples/consumer/.github/workflows/materialize.yml": "GitVibe materialize",
+  "examples/consumer/.github/workflows/investigate.yml": "GitVibe investigate",
+  "examples/consumer/.github/workflows/develop.yml": "GitVibe develop",
+  "examples/consumer/.github/workflows/address-feedback.yml": "GitVibe address feedback",
+};
+
+describe("GitVibe workflow run names", () => {
+  it("defines run-name in all workflows with [git-vibe] prefix and stage identifier", () => {
+    for (const spec of workflowRunNameSpecs) {
+      const workflow = readWorkflow(spec.file);
+      const runName = workflow["run-name"];
+      expect(runName, `${spec.file} should define run-name`).toBeDefined();
+      expect(runName, `${spec.file} run-name should contain [git-vibe]`).toContain("[git-vibe]");
+      expect(runName, `${spec.file} run-name should contain stage [${spec.stage}]`).toContain(
+        `[${spec.stage}]`,
+      );
+      if (spec.artifact) {
+        expect(runName, `${spec.file} run-name should reference ${spec.artifact}`).toContain(
+          spec.artifact,
+        );
+      }
+      if (spec.multiArtifact) {
+        expect(runName, `${spec.file} run-name should handle multiple artifact types`).toContain(
+          "inputs.discussion-number",
+        );
+        expect(runName, `${spec.file} run-name should handle multiple artifact types`).toContain(
+          "inputs.issue-number",
+        );
+      }
+    }
+  });
+
+  it("preserves static name field in all workflows", () => {
+    for (const [file, expectedName] of Object.entries(workflowStaticNames)) {
+      const workflow = readWorkflow(file);
+      expect(workflow.name, `${file} should preserve static name`).toBe(expectedName);
+    }
+  });
+});
 
 describe("GitVibe workflow wiring", () => {
   it("passes AI environment into reusable action source runs", () => {


### PR DESCRIPTION
## Summary

Adds dynamic GitHub Actions `run-name` expressions for the GitVibe reusable workflows and the consumer example wrapper workflows so run display names identify the stage and target artifact.

Closes #12.

## Implementation Notes

- Preserves each existing top-level workflow `name` value.
- Adds top-level `run-name` entries for `validate`, `summarize`, `materialize`, `investigate`, `develop`, and `address-feedback` workflows.
- Mirrors the same run-name behavior in `examples/consumer/.github/workflows/` wrappers.
- Uses the accepted generic fallback for invalid `validate` runs when both issue and discussion inputs are empty.
- Extends `tests/workflows.test.mjs` to verify run-name coverage and preserved workflow names.

## Tests

- Workflow run 25610440829 was reported by GitVibe review-matrix as passing the repository gate: Prettier, ESLint, typecheck, Vitest coverage, build, actionlint, and prod audit.

## Risks

No blocking risks were reported by review-matrix. The validate workflow fallback only affects invalid empty-input runs, which the maintainer confirmed do not have a manual use case.

## GitVibe Traceability

Refs #12