### PR TITLE
chore: update repository owner and runner labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature discussions
-    url: https://github.com/Z-M-Huang/git-vibe/discussions
+    url: https://github.com/markhuangai/git-vibe/discussions
     about: Prefer a discussion for feature ideas when GitHub Discussions are enabled.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,5 +2,6 @@ self-hosted-runner:
   labels:
     - pipeline
     - app
+    - rootless-docker
 
 config-variables: null

--- a/.github/git-vibe.yml
+++ b/.github/git-vibe.yml
@@ -26,7 +26,7 @@ commands:
   allow_external_agent_mentions: false
 
 runner:
-  default: pipeline
+  default: rootless-docker
 
 event_delivery:
   mode: webhook

--- a/.github/workflows/address-feedback.yml
+++ b/.github/workflows/address-feedback.yml
@@ -12,7 +12,7 @@ on:
         description: Runner label for all jobs.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for the feedback remediation job.
         required: false
@@ -53,7 +53,7 @@ on:
         description: Runner label for all jobs.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for the feedback remediation job.
         required: false

--- a/.github/workflows/ai-smoke.yml
+++ b/.github/workflows/ai-smoke.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   local-proxy:
     if: ${{ inputs.run-local-proxy }}
-    runs-on: pipeline
+    runs-on: rootless-docker
     timeout-minutes: 10
     permissions:
       contents: read
@@ -51,7 +51,7 @@ jobs:
 
   codex:
     if: ${{ inputs.run-codex }}
-    runs-on: pipeline
+    runs-on: rootless-docker
     timeout-minutes: 10
     permissions:
       contents: read
@@ -105,7 +105,7 @@ jobs:
 
   claude-code:
     if: ${{ inputs.run-claude-code }}
-    runs-on: pipeline
+    runs-on: rootless-docker
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -20,11 +20,11 @@ permissions:
   packages: write
 
 env:
-  GITVIBE_IMAGE: ghcr.io/z-m-huang/git-vibe:${{ github.sha }}
+  GITVIBE_IMAGE: ghcr.io/markhuangai/git-vibe:${{ github.sha }}
 
 jobs:
   build:
-    runs-on: pipeline
+    runs-on: rootless-docker
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
@@ -38,7 +38,7 @@ jobs:
           push: true
           tags: |
             ${{ env.GITVIBE_IMAGE }}
-            ghcr.io/z-m-huang/git-vibe:latest
+            ghcr.io/markhuangai/git-vibe:latest
 
   deploy:
     runs-on: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   quality:
-    runs-on: pipeline
+    runs-on: rootless-docker
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -12,7 +12,7 @@ on:
         description: Runner label for all jobs.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       implementation_timeout_minutes:
         description: Maximum minutes for the implementation job.
         required: false
@@ -78,7 +78,7 @@ on:
         description: Runner label for all jobs.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       implementation_timeout_minutes:
         description: Maximum minutes for the implementation job.
         required: false

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -12,7 +12,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for the investigation job.
         required: false
@@ -53,7 +53,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for the investigation job.
         required: false

--- a/.github/workflows/materialize.yml
+++ b/.github/workflows/materialize.yml
@@ -12,7 +12,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for this job.
         required: false
@@ -53,7 +53,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for this job.
         required: false

--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -12,7 +12,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for the summarize job.
         required: false
@@ -53,7 +53,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for the summarize job.
         required: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for this job.
         required: false
@@ -65,7 +65,7 @@ on:
         description: Runner label for this job.
         required: false
         type: string
-        default: pipeline
+        default: rootless-docker
       timeout_minutes:
         description: Maximum minutes for this job.
         required: false

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Z-M-Huang/git-vibe"><img src="https://img.shields.io/github/stars/Z-M-Huang/git-vibe?style=flat-square&logo=github" alt="GitHub stars" /></a>
-  <a href="https://github.com/Z-M-Huang/git-vibe/issues"><img src="https://img.shields.io/github/issues/Z-M-Huang/git-vibe?style=flat-square&logo=github" alt="GitHub issues" /></a>
-  <a href="https://github.com/Z-M-Huang/git-vibe/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Z-M-Huang/git-vibe?style=flat-square" alt="License" /></a>
+  <a href="https://github.com/markhuangai/git-vibe"><img src="https://img.shields.io/github/stars/markhuangai/git-vibe?style=flat-square&logo=github" alt="GitHub stars" /></a>
+  <a href="https://github.com/markhuangai/git-vibe/issues"><img src="https://img.shields.io/github/issues/markhuangai/git-vibe?style=flat-square&logo=github" alt="GitHub issues" /></a>
+  <a href="https://github.com/markhuangai/git-vibe/blob/main/LICENSE"><img src="https://img.shields.io/github/license/markhuangai/git-vibe?style=flat-square" alt="License" /></a>
   <img src="https://img.shields.io/badge/node-22-339933?style=flat-square&logo=node.js&logoColor=white" alt="Node.js 22" />
   <img src="https://img.shields.io/badge/pnpm-10.33.3-F69220?style=flat-square&logo=pnpm&logoColor=white" alt="pnpm 10.33.3" />
 </p>
@@ -21,7 +21,7 @@
   <img src="https://img.shields.io/badge/coverage-%3E%3D90%25-brightgreen?style=flat-square" alt="Coverage threshold" />
   <img src="https://img.shields.io/badge/Docker-GHCR-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker image on GHCR" />
   <img src="https://img.shields.io/badge/AI_SDK-agentool-111827?style=flat-square" alt="AI SDK and agentool" />
-  <img src="https://visitor-badge.laobi.icu/badge?page_id=Z-M-Huang.git-vibe&style=flat-square" alt="Visitors" />
+  <img src="https://visitor-badge.laobi.icu/badge?page_id=markhuangai.git-vibe&style=flat-square" alt="Visitors" />
 </p>
 
 <p align="center">

--- a/app/README.md
+++ b/app/README.md
@@ -65,7 +65,7 @@ docker compose -f docker-compose.yml up -d
 ```
 
 The compose deployment expects runtime values from the host environment. In CI/CD,
-the `GitVibe app deploy` workflow builds `ghcr.io/z-m-huang/git-vibe`, then runs
+the `GitVibe app deploy` workflow builds `ghcr.io/markhuangai/git-vibe`, then runs
 the compose deployment on the self-hosted runner.
 The container listens on port `3000`; change the host-side mapping in Compose or
 an override file instead of setting a `PORT` variable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   git-vibe-app:
-    image: ${GITVIBE_IMAGE:-ghcr.io/z-m-huang/git-vibe:latest}
+    image: ${GITVIBE_IMAGE:-ghcr.io/markhuangai/git-vibe:latest}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- update repository owner references to markhuangai/git-vibe
- move workflow defaults from pipeline to rootless-docker
- allow rootless-docker in actionlint config

## Validation
- corepack pnpm check

Direct pushes to main and dev were rejected by repository rules, so this PR is the required path to merge main into dev.