### PR TITLE
Add local git-vibe-setup initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,18 +120,27 @@ iterations.
 
 ## Quick Start
 
-### 1. Copy the consumer starter
+### 1. Install the consumer starter
 
 Run this from the repository that should use GitVibe:
 
 ```bash
-cp -R /path/to/git-vibe/examples/consumer/.github /path/to/your-repo/.github
-cp -R /path/to/git-vibe/examples/consumer/.git-vibe /path/to/your-repo/.git-vibe
+npx --package=@git-vibe/app git-vibe-setup
 ```
 
-Copy only `examples/consumer/.github` and `examples/consumer/.git-vibe`. Do not
-copy GitVibe's internal action folders such as `investigate/`, `implement/`,
-`app/`, or `src/`.
+`git-vibe-setup` fetches the latest stable `markhuangai/git-vibe` release,
+copies the consumer starter from this repository, pins generated reusable
+workflow refs to that release tag, and stops without writing if any target file
+already exists.
+
+It creates:
+
+- `.github/git-vibe.yml`
+- `.github/workflows/*.yml`
+- `.git-vibe/role-group/*.md`
+
+The installer is local-only. It does not authenticate to GitHub, create
+commits, open pull requests, or write secrets and variables for you.
 
 ### 2. Configure the consumer repo
 
@@ -146,7 +155,7 @@ The starter workflows call the public reusable workflow namespace:
 ```yaml
 jobs:
   develop:
-    uses: markhuangai/git-vibe/.github/workflows/develop.yml@v1.0.0
+    uses: markhuangai/git-vibe/.github/workflows/develop.yml@<latest-stable-tag>
 ```
 
 Reusable workflows operate on the repository where the workflow run starts
@@ -157,6 +166,9 @@ input.
 
 Secrets belong in GitHub repository or organization secrets, not in
 `.github/git-vibe.yml`.
+
+`git-vibe-setup` prints this list after it writes files. It does not collect or
+store secret values.
 
 | Name                   | Required | Purpose                                                                     |
 | ---------------------- | -------- | --------------------------------------------------------------------------- |

--- a/examples/consumer/README.md
+++ b/examples/consumer/README.md
@@ -1,13 +1,20 @@
 # GitVibe Consumer Example
 
-Copy the `.github` and `.git-vibe` directories from this folder into a repository that should use GitVibe.
+`git-vibe-setup` installs this starter into a consumer repository:
 
 ```bash
-cp -R examples/consumer/.github /path/to/consumer-repo/.github
-cp -R examples/consumer/.git-vibe /path/to/consumer-repo/.git-vibe
+npx --package=@git-vibe/app git-vibe-setup
 ```
 
-Then configure repository or organization secrets and variables as described in the root `README.md`.
+The installer copies `.github` and `.git-vibe`, rewrites reusable workflow refs
+to the latest stable GitVibe release tag, and fails closed if GitHub release
+lookup or target-file validation cannot complete before writing.
+
+It will not overwrite existing target files. Remove any existing GitVibe starter
+files before running setup again.
+
+Then configure repository or organization secrets and variables as described in
+the root `README.md`.
 
 Use `GITVIBE_AI_ENV_JSON.example.json` as the shape for the
 `GITVIBE_AI_ENV_JSON` secret. Do not commit real token values.

--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "type": "module",
   "packageManager": "pnpm@10.33.3",
   "bin": {
-    "git-vibe-app": "./dist/app/server.js"
+    "git-vibe-app": "./dist/app/server.js",
+    "git-vibe-setup": "./dist/setup/cli.js"
   },
   "files": [
     "dist",
+    "examples/consumer/.github",
+    "examples/consumer/.git-vibe",
+    "examples/consumer/GITVIBE_AI_ENV_JSON.example.json",
     "prompts",
     "schemas",
     "README.md",

--- a/src/setup/cli.ts
+++ b/src/setup/cli.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import {
+  blockingInstallPaths,
+  buildInstallFiles,
+  existingFilesError,
+  installFiles,
+} from "./install.js";
+import { renderManualSetupInstructions } from "./instructions.js";
+import { latestStableReleaseTag } from "./releases.js";
+
+interface SetupCliRuntime {
+  cwd?: string;
+  error?: (message: string) => void;
+  fetchImpl?: typeof fetch;
+  log?: (message: string) => void;
+  repositoryRoot?: string;
+}
+
+export async function runSetup(runtime: SetupCliRuntime = {}): Promise<void> {
+  const cwd = runtime.cwd || process.cwd();
+  const repositoryRoot = runtime.repositoryRoot || packageRoot();
+  const releaseTag = await latestStableReleaseTag(runtime.fetchImpl || fetch);
+  const files = buildInstallFiles({ cwd, releaseTag, repositoryRoot });
+  const blockingPaths = blockingInstallPaths(files);
+
+  if (blockingPaths.length > 0) throw existingFilesError(blockingPaths, cwd);
+
+  installFiles(files);
+  (runtime.log || console.log)(renderManualSetupInstructions(releaseTag));
+}
+
+export async function setupCli(runtime: SetupCliRuntime = {}): Promise<number> {
+  try {
+    await runSetup(runtime);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    (runtime.error || console.error)(message);
+    return 1;
+  }
+}
+
+function packageRoot(): string {
+  return fileURLToPath(new URL("../../", import.meta.url));
+}
+
+/* c8 ignore start */
+if (isDirectRun(import.meta.url)) {
+  const exitCode = await setupCli();
+  process.exitCode = exitCode;
+}
+/* c8 ignore stop */
+
+function isDirectRun(moduleUrl: string, entrypoint = process.argv[1]): boolean {
+  return Boolean(entrypoint && moduleUrl === pathToFileURL(resolve(entrypoint)).href);
+}

--- a/src/setup/install.ts
+++ b/src/setup/install.ts
@@ -1,0 +1,128 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+export interface InstallFile {
+  content: string;
+  sourcePath: string;
+  targetPath: string;
+}
+
+interface InstallSource {
+  sourceDirectory: string;
+  targetDirectory: string;
+}
+
+export function buildInstallFiles(options: {
+  cwd: string;
+  releaseTag: string;
+  repositoryRoot: string;
+}): InstallFile[] {
+  return installSources(options.repositoryRoot).flatMap((source) =>
+    listRelativeFiles(source.sourceDirectory).map((relativePath) => {
+      const sourcePath = join(source.sourceDirectory, relativePath);
+      const targetPath = join(options.cwd, source.targetDirectory, relativePath);
+      const content = readFileSync(sourcePath, "utf8");
+
+      return {
+        content: pinWorkflowReleaseRefs(content, options.releaseTag),
+        sourcePath,
+        targetPath,
+      };
+    }),
+  );
+}
+
+export function blockingInstallPaths(files: InstallFile[]): string[] {
+  return files
+    .map((file) => file.targetPath)
+    .filter((targetPath) => existsSync(targetPath))
+    .sort();
+}
+
+export function installFiles(files: InstallFile[]): void {
+  const createdDirectories: string[] = [];
+  const createdFiles: string[] = [];
+
+  try {
+    for (const file of files) {
+      ensureDirectory(dirname(file.targetPath), createdDirectories);
+      writeFileSync(file.targetPath, file.content, { flag: "wx" });
+      createdFiles.push(file.targetPath);
+    }
+  } catch (error) {
+    rollbackInstall(createdFiles, createdDirectories);
+    throw error;
+  }
+}
+
+export function existingFilesError(paths: string[], cwd: string): Error {
+  const listed = paths.map((path) => `- ${relative(cwd, path) || path}`).join("\n");
+  return new Error(
+    `git-vibe-setup found existing GitVibe files and did not overwrite them:\n${listed}\nRemove the listed files before running setup again.`,
+  );
+}
+
+export function pinWorkflowReleaseRefs(content: string, releaseTag: string): string {
+  return content.replace(
+    /(uses:\s*markhuangai\/git-vibe\/\.github\/workflows\/[^\s@]+)@[^\s]+/g,
+    `$1@${releaseTag}`,
+  );
+}
+
+function installSources(repositoryRoot: string): InstallSource[] {
+  return [
+    {
+      sourceDirectory: join(repositoryRoot, "examples", "consumer", ".github"),
+      targetDirectory: ".github",
+    },
+    {
+      sourceDirectory: join(repositoryRoot, "examples", "consumer", ".git-vibe"),
+      targetDirectory: ".git-vibe",
+    },
+  ];
+}
+
+function listRelativeFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return listRelativeFiles(entryPath).map((path) => join(entry.name, path));
+      }
+      /* c8 ignore next */
+      return entry.isFile() ? [entry.name] : [];
+    })
+    .sort();
+}
+
+function ensureDirectory(directory: string, createdDirectories: string[]): void {
+  const missing = missingDirectories(directory);
+  for (const path of missing) {
+    mkdirSync(path);
+    createdDirectories.push(path);
+  }
+}
+
+function missingDirectories(directory: string): string[] {
+  const missing: string[] = [];
+  let current = directory;
+
+  while (!existsSync(current)) {
+    missing.push(current);
+    const parent = dirname(current);
+    /* c8 ignore next */
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return missing.reverse();
+}
+
+function rollbackInstall(createdFiles: string[], createdDirectories: string[]): void {
+  for (const file of [...createdFiles].reverse()) {
+    rmSync(file, { force: true });
+  }
+  for (const directory of [...createdDirectories].reverse()) {
+    rmSync(directory, { force: true, recursive: false });
+  }
+}

--- a/src/setup/install.ts
+++ b/src/setup/install.ts
@@ -65,7 +65,7 @@ export function existingFilesError(paths: string[], cwd: string): Error {
 export function pinWorkflowReleaseRefs(content: string, releaseTag: string): string {
   return content.replace(
     /(uses:\s*markhuangai\/git-vibe\/\.github\/workflows\/[^\s@]+)@[^\s]+/g,
-    `$1@${releaseTag}`,
+    (_match, workflowReference) => `${workflowReference}@${releaseTag}`,
   );
 }
 

--- a/src/setup/instructions.ts
+++ b/src/setup/instructions.ts
@@ -1,0 +1,28 @@
+const requiredSecrets = [
+  ["GITVIBE_AI_ENV_JSON", "JSON env bundle for AI provider config and CLI auth."],
+  ["GITVIBE_GITHUB_TOKEN", "Fine-grained PAT for GitVibe workflow and server writes."],
+  ["WEBHOOK_SECRET", "Webhook shared secret mapped to GITHUB_WEBHOOK_SECRET in deployment."],
+] as const;
+
+const usefulVariables = [
+  "GITVIBE_BASE_BRANCH",
+  "GITVIBE_DISCUSSION_CATEGORY",
+  "GITVIBE_RUNNER",
+  "GITVIBE_LOG_LEVEL",
+] as const;
+
+export function renderManualSetupInstructions(releaseTag: string): string {
+  const lines = [
+    `GitVibe starter files installed with reusable workflows pinned to ${releaseTag}.`,
+    "",
+    "Configure these GitHub secrets manually before running the workflows:",
+    ...requiredSecrets.map(([name, description]) => `- ${name}: ${description}`),
+    "",
+    "Optional repository variables:",
+    ...usefulVariables.map((name) => `- ${name}`),
+    "",
+    `Reference bundle shape: https://github.com/markhuangai/git-vibe/blob/${releaseTag}/examples/consumer/GITVIBE_AI_ENV_JSON.example.json`,
+  ];
+
+  return lines.join("\n");
+}

--- a/src/setup/releases.ts
+++ b/src/setup/releases.ts
@@ -9,6 +9,7 @@ export interface GitHubRelease {
 export class ReleaseLookupError extends Error {}
 
 const releasesUrl = "https://api.github.com/repos/markhuangai/git-vibe/releases";
+const releasesPerPage = 100;
 
 export async function latestStableReleaseTag(fetchImpl: typeof fetch = fetch): Promise<string> {
   const releases = await fetchReleases(fetchImpl);
@@ -29,10 +30,21 @@ export function selectLatestStableRelease(releases: GitHubRelease[]): GitHubRele
 }
 
 async function fetchReleases(fetchImpl: typeof fetch): Promise<GitHubRelease[]> {
+  const releases: GitHubRelease[] = [];
+
+  for (let page = 1; ; page += 1) {
+    const data = await fetchReleasePage(fetchImpl, page);
+    releases.push(...data);
+
+    if (data.length < releasesPerPage) return releases;
+  }
+}
+
+async function fetchReleasePage(fetchImpl: typeof fetch, page: number): Promise<GitHubRelease[]> {
   let response: Response;
 
   try {
-    response = await fetchImpl(releasesUrl, {
+    response = await fetchImpl(releasePageUrl(page), {
       headers: {
         accept: "application/vnd.github+json",
         "user-agent": "git-vibe-setup",
@@ -51,6 +63,13 @@ async function fetchReleases(fetchImpl: typeof fetch): Promise<GitHubRelease[]> 
   } catch {
     throw unavailableReleaseError();
   }
+}
+
+function releasePageUrl(page: number): string {
+  const url = new URL(releasesUrl);
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("per_page", String(releasesPerPage));
+  return url.toString();
 }
 
 function compareReleaseFreshness(left: GitHubRelease, right: GitHubRelease): number {

--- a/src/setup/releases.ts
+++ b/src/setup/releases.ts
@@ -1,0 +1,68 @@
+export interface GitHubRelease {
+  created_at?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  published_at?: string;
+  tag_name?: string;
+}
+
+export class ReleaseLookupError extends Error {}
+
+const releasesUrl = "https://api.github.com/repos/markhuangai/git-vibe/releases";
+
+export async function latestStableReleaseTag(fetchImpl: typeof fetch = fetch): Promise<string> {
+  const releases = await fetchReleases(fetchImpl);
+  const release = selectLatestStableRelease(releases);
+  if (!release?.tag_name) {
+    throw new ReleaseLookupError(
+      "git-vibe-setup could not check the latest GitVibe update because no stable release is available. No files were written.",
+    );
+  }
+
+  return release.tag_name;
+}
+
+export function selectLatestStableRelease(releases: GitHubRelease[]): GitHubRelease | undefined {
+  return releases
+    .filter((release) => !release.draft && !release.prerelease && release.tag_name)
+    .sort(compareReleaseFreshness)[0];
+}
+
+async function fetchReleases(fetchImpl: typeof fetch): Promise<GitHubRelease[]> {
+  let response: Response;
+
+  try {
+    response = await fetchImpl(releasesUrl, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "git-vibe-setup",
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+  } catch {
+    throw unavailableReleaseError();
+  }
+
+  if (!response.ok) throw unavailableReleaseError();
+
+  try {
+    const data = await response.json();
+    return Array.isArray(data) ? (data as GitHubRelease[]) : [];
+  } catch {
+    throw unavailableReleaseError();
+  }
+}
+
+function compareReleaseFreshness(left: GitHubRelease, right: GitHubRelease): number {
+  return releaseTime(right) - releaseTime(left);
+}
+
+function releaseTime(release: GitHubRelease): number {
+  return Date.parse(release.published_at || release.created_at || "") || 0;
+}
+
+function unavailableReleaseError(): ReleaseLookupError {
+  return new ReleaseLookupError(
+    "git-vibe-setup could not check the latest GitVibe update because the GitHub release service is unavailable. No files were written.",
+  );
+}

--- a/tests/docs.test.mjs
+++ b/tests/docs.test.mjs
@@ -17,4 +17,18 @@ describe("documentation workflow descriptions", () => {
     expect(workflow).toContain("PR gvi:ready-for-approval");
     expect(workflow).toContain("investigate` in PR-feedback mode");
   });
+
+  it("documents the local git-vibe-setup installer behavior", () => {
+    const readme = readFileSync("README.md", "utf8");
+    const exampleReadme = readFileSync("examples/consumer/README.md", "utf8");
+
+    expect(readme).toContain("git-vibe-setup");
+    expect(readme).toContain("stops without writing if any target file");
+    expect(readme).toContain("already exists.");
+    expect(readme).toContain("pins generated reusable");
+    expect(readme).toContain("workflow refs to that release tag");
+    expect(exampleReadme).toContain("fails closed if GitHub release");
+    expect(exampleReadme).toContain("lookup or target-file validation");
+    expect(exampleReadme).toContain("It will not overwrite existing target files.");
+  });
 });

--- a/tests/setup-cli.test.mjs
+++ b/tests/setup-cli.test.mjs
@@ -1,0 +1,323 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { existingFilesError, installFiles } from "../src/setup/install.ts";
+import { runSetup, setupCli } from "../src/setup/cli.ts";
+import { latestStableReleaseTag, selectLatestStableRelease } from "../src/setup/releases.ts";
+
+const repositoryRoot = process.cwd();
+/** @type {string[]} */
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("git-vibe-setup", () => {
+  it("exposes the setup executable and ships the consumer starter assets", () => {
+    const packageJson = JSON.parse(readFileSync(join(repositoryRoot, "package.json"), "utf8"));
+
+    expect(packageJson.bin["git-vibe-setup"]).toBe("./dist/setup/cli.js");
+    expect(packageJson.files).toEqual(
+      expect.arrayContaining([
+        "examples/consumer/.github",
+        "examples/consumer/.git-vibe",
+        "examples/consumer/GITVIBE_AI_ENV_JSON.example.json",
+      ]),
+    );
+  });
+});
+
+describe("git-vibe-setup installation", () => {
+  it("installs the consumer starter, including role prompts, and pins workflow refs", async () => {
+    const cwd = workspace();
+    /** @type {string[]} */
+    const logs = [];
+
+    await runSetup({
+      cwd,
+      fetchImpl: fetchOk([
+        release({ draft: true, published_at: "2026-05-15T00:00:00Z", tag_name: "v9.9.9" }),
+        release({
+          prerelease: true,
+          published_at: "2026-05-14T00:00:00Z",
+          tag_name: "v2.0.0-rc1",
+        }),
+        release({ published_at: "2026-05-13T00:00:00Z", tag_name: "v1.2.3" }),
+      ]),
+      log: (message) => logs.push(message),
+      repositoryRoot,
+    });
+
+    expect(readFileSync(join(cwd, ".github", "git-vibe.yml"), "utf8")).toContain("version: 1");
+    expect(existsSync(join(cwd, ".git-vibe", "role-group", "correctness.md"))).toBe(true);
+
+    const installedWorkflows = workflowNames(join(cwd, ".github"));
+    const exampleWorkflows = workflowNames(join(repositoryRoot, "examples", "consumer", ".github"));
+    expect(installedWorkflows).toEqual(exampleWorkflows);
+
+    for (const name of installedWorkflows) {
+      const workflow = readFileSync(join(cwd, ".github", "workflows", name), "utf8");
+      expect(workflow).toContain("@v1.2.3");
+      expect(workflow).not.toContain("@main");
+    }
+  });
+
+  it("prints the manual secret and variable instructions after installation", async () => {
+    const cwd = workspace();
+    /** @type {string[]} */
+    const logs = [];
+
+    await runSetup({
+      cwd,
+      fetchImpl: fetchOk([release({ tag_name: "v1.2.3" })]),
+      log: (message) => logs.push(message),
+      repositoryRoot,
+    });
+
+    expect(logs[0]).toContain("GITVIBE_AI_ENV_JSON");
+    expect(logs[0]).toContain("GITVIBE_GITHUB_TOKEN");
+    expect(logs[0]).toContain("WEBHOOK_SECRET");
+    expect(logs[0]).toContain("GITVIBE_BASE_BRANCH");
+    expect(logs[0]).toContain("/blob/v1.2.3/examples/consumer/GITVIBE_AI_ENV_JSON.example.json");
+  });
+
+  it("returns success from the CLI wrapper and resolves the packaged examples by default", async () => {
+    const cwd = workspace();
+    /** @type {string[]} */
+    const logs = [];
+
+    const exitCode = await setupCli({
+      cwd,
+      fetchImpl: fetchOk([release({ tag_name: "v1.2.3" })]),
+      log: (message) => logs.push(message),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(cwd, ".github", "git-vibe.yml"))).toBe(true);
+    expect(logs[0]).toContain("GitVibe starter files installed");
+  });
+
+  it("falls back to process defaults for cwd, fetch, and console logging", async () => {
+    const cwd = workspace();
+    const originalCwd = process.cwd();
+    const originalFetch = globalThis.fetch;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    globalThis.fetch = fetchOk([release({ tag_name: "v1.2.3" })]);
+    process.chdir(cwd);
+
+    try {
+      await expect(setupCli()).resolves.toBe(0);
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("GitVibe starter files installed"));
+    } finally {
+      process.chdir(originalCwd);
+      globalThis.fetch = originalFetch;
+      log.mockRestore();
+    }
+  });
+});
+
+describe("git-vibe-setup failures", () => {
+  it("falls back to console.error when the CLI wrapper reports failures", async () => {
+    const cwd = workspace();
+    const originalCwd = process.cwd();
+    const originalFetch = globalThis.fetch;
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    globalThis.fetch = async () => new globalThis.Response("", { status: 503 });
+    process.chdir(cwd);
+
+    try {
+      await expect(setupCli()).resolves.toBe(1);
+      expect(error).toHaveBeenCalledWith(expect.stringContaining("service is unavailable"));
+    } finally {
+      process.chdir(originalCwd);
+      globalThis.fetch = originalFetch;
+      error.mockRestore();
+    }
+  });
+
+  it("fails without writing when any target file already exists", async () => {
+    const cwd = workspace();
+    /** @type {string[]} */
+    const errors = [];
+
+    mkdirSync(join(cwd, ".github", "workflows"), { recursive: true });
+    writeFileSync(join(cwd, ".github", "workflows", "develop.yml"), "existing");
+
+    const exitCode = await setupCli({
+      cwd,
+      error: (message) => errors.push(message),
+      fetchImpl: fetchOk([release({ tag_name: "v1.2.3" })]),
+      log: () => undefined,
+      repositoryRoot,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors[0]).toContain(".github/workflows/develop.yml");
+    expect(existsSync(join(cwd, ".github", "git-vibe.yml"))).toBe(false);
+    expect(existsSync(join(cwd, ".git-vibe"))).toBe(false);
+  });
+
+  it("fails without writing when the latest release lookup is unavailable", async () => {
+    const cwd = workspace();
+    /** @type {string[]} */
+    const errors = [];
+
+    const exitCode = await setupCli({
+      cwd,
+      error: (message) => errors.push(message),
+      fetchImpl: async () => new globalThis.Response("", { status: 503 }),
+      log: () => undefined,
+      repositoryRoot,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors[0]).toContain("could not check the latest GitVibe update");
+    expect(errors[0]).toContain("service is unavailable");
+    expect(existsSync(join(cwd, ".github"))).toBe(false);
+  });
+
+  it("fails without writing when no stable release exists", async () => {
+    const cwd = workspace();
+    /** @type {string[]} */
+    const errors = [];
+
+    const exitCode = await setupCli({
+      cwd,
+      error: (message) => errors.push(message),
+      fetchImpl: fetchOk([
+        release({ draft: true, tag_name: "v2.0.0" }),
+        release({ prerelease: true, tag_name: "v2.0.0-rc1" }),
+      ]),
+      log: () => undefined,
+      repositoryRoot,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors[0]).toContain("no stable release is available");
+    expect(existsSync(join(cwd, ".github"))).toBe(false);
+  });
+});
+
+describe("stable release selection", () => {
+  it("ignores draft and prerelease releases when choosing the latest stable tag", () => {
+    const releaseTag = selectLatestStableRelease([
+      release({ draft: true, published_at: "2026-05-17T00:00:00Z", tag_name: "v3.0.0" }),
+      release({ prerelease: true, published_at: "2026-05-16T00:00:00Z", tag_name: "v2.0.0-rc1" }),
+      release({ published_at: "2026-05-15T00:00:00Z", tag_name: "v1.3.0" }),
+      release({ published_at: "2026-05-14T00:00:00Z", tag_name: "v1.2.9" }),
+    ])?.tag_name;
+
+    expect(releaseTag).toBe("v1.3.0");
+  });
+
+  it("falls back to created_at when published_at is unavailable", () => {
+    const releaseTag = selectLatestStableRelease([
+      release({ created_at: "2026-05-14T00:00:00Z", published_at: undefined, tag_name: "v1.2.9" }),
+      release({ created_at: "2026-05-15T00:00:00Z", published_at: undefined, tag_name: "v1.3.0" }),
+    ])?.tag_name;
+
+    expect(releaseTag).toBe("v1.3.0");
+  });
+
+  it("fails closed when the release request throws or returns invalid JSON", async () => {
+    await expect(
+      latestStableReleaseTag(async () => Promise.reject(new Error("offline"))),
+    ).rejects.toThrow("service is unavailable");
+    await expect(
+      latestStableReleaseTag(
+        async () =>
+          new globalThis.Response("{", {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          }),
+      ),
+    ).rejects.toThrow("service is unavailable");
+    await expect(
+      latestStableReleaseTag(
+        async () =>
+          new globalThis.Response(JSON.stringify({ tag_name: "v1.2.3" }), {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          }),
+      ),
+    ).rejects.toThrow("no stable release is available");
+  });
+});
+
+describe("installation rollback", () => {
+  it("removes created files when a later write fails", () => {
+    const cwd = workspace();
+    const target = join(cwd, ".github", "git-vibe.yml");
+
+    mkdirSync(join(cwd, ".github"), { recursive: true });
+    writeFileSync(target, "existing");
+
+    expect(() =>
+      installFiles([
+        {
+          content: "first",
+          sourcePath: "first",
+          targetPath: join(cwd, ".git-vibe", "role-group", "correctness.md"),
+        },
+        {
+          content: "second",
+          sourcePath: "second",
+          targetPath: target,
+        },
+      ]),
+    ).toThrow();
+
+    expect(existsSync(join(cwd, ".git-vibe", "role-group", "correctness.md"))).toBe(false);
+    expect(readFileSync(target, "utf8")).toBe("existing");
+  });
+
+  it("reports absolute paths when relative rendering is empty", () => {
+    expect(existingFilesError([repositoryRoot], repositoryRoot).message).toContain(repositoryRoot);
+  });
+});
+
+function workspace() {
+  const directory = mkdtempSync(join(tmpdir(), "git-vibe-setup-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+/** @param {string} directory */
+function workflowNames(directory) {
+  return readdirSync(join(directory, "workflows")).sort();
+}
+
+/** @param {Partial<import("../src/setup/releases.ts").GitHubRelease>} overrides */
+function release(overrides = {}) {
+  return {
+    created_at: "2026-05-10T00:00:00Z",
+    draft: false,
+    prerelease: false,
+    published_at: "2026-05-10T00:00:00Z",
+    tag_name: "v1.0.0",
+    ...overrides,
+  };
+}
+
+/** @param {import("../src/setup/releases.ts").GitHubRelease[]} data */
+function fetchOk(data) {
+  return async () =>
+    new globalThis.Response(JSON.stringify(data), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    });
+}

--- a/tests/setup-cli.test.mjs
+++ b/tests/setup-cli.test.mjs
@@ -10,7 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { existingFilesError, installFiles } from "../src/setup/install.ts";
+import { existingFilesError, installFiles, pinWorkflowReleaseRefs } from "../src/setup/install.ts";
 import { runSetup, setupCli } from "../src/setup/cli.ts";
 import { latestStableReleaseTag, selectLatestStableRelease } from "../src/setup/releases.ts";
 
@@ -311,6 +311,19 @@ describe("installation rollback", () => {
 
   it("reports absolute paths when relative rendering is empty", () => {
     expect(existingFilesError([repositoryRoot], repositoryRoot).message).toContain(repositoryRoot);
+  });
+});
+
+describe("workflow ref pinning", () => {
+  it("preserves dollar sequences in the release tag", () => {
+    const pinned = pinWorkflowReleaseRefs(
+      "uses: markhuangai/git-vibe/.github/workflows/develop.yml@v1\n",
+      "release-$1-${tag}",
+    );
+
+    expect(pinned).toContain(
+      "uses: markhuangai/git-vibe/.github/workflows/develop.yml@release-$1-${tag}",
+    );
   });
 });
 

--- a/tests/setup-cli.test.mjs
+++ b/tests/setup-cli.test.mjs
@@ -233,6 +233,30 @@ describe("stable release selection", () => {
     expect(releaseTag).toBe("v1.3.0");
   });
 
+  it("checks later release pages before reporting that no stable release exists", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) =>
+      release({
+        draft: index % 2 === 0,
+        prerelease: index % 2 === 1,
+        published_at: `2026-05-${String(14 - Math.floor(index / 10)).padStart(2, "0")}T00:00:00Z`,
+        tag_name: `v9.0.0-${index}`,
+      }),
+    );
+    const fetchImpl = vi.fn(
+      fetchPages([
+        firstPage,
+        [release({ published_at: "2026-05-01T00:00:00Z", tag_name: "v1.2.3" })],
+      ]),
+    );
+
+    await expect(latestStableReleaseTag(fetchImpl)).resolves.toBe("v1.2.3");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][0]).toContain("page=1");
+    expect(fetchImpl.mock.calls[0][0]).toContain("per_page=100");
+    expect(fetchImpl.mock.calls[1][0]).toContain("page=2");
+    expect(fetchImpl.mock.calls[1][0]).toContain("per_page=100");
+  });
+
   it("fails closed when the release request throws or returns invalid JSON", async () => {
     await expect(
       latestStableReleaseTag(async () => Promise.reject(new Error("offline"))),
@@ -320,4 +344,17 @@ function fetchOk(data) {
       headers: { "content-type": "application/json" },
       status: 200,
     });
+}
+
+/** @param {import("../src/setup/releases.ts").GitHubRelease[][]} pages */
+function fetchPages(pages) {
+  /** @param {string | URL | globalThis.Request} url */
+  return async (url) => {
+    const page = Number(new URL(String(url)).searchParams.get("page") || "1");
+    const data = pages[page - 1] || [];
+    return new globalThis.Response(JSON.stringify(data), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    });
+  };
 }


### PR DESCRIPTION
## Summary
- Adds packaged `git-vibe-setup` initializer for consumer repositories.
- Copies consumer `.github` and `.git-vibe` starter files, pins reusable workflow refs to the latest stable release, and refuses to overwrite existing target files.
- Prints manual secret and variable setup instructions without collecting credentials.

## Implementation Notes
- `src/setup/cli.ts` wires release lookup, file validation, install, and output.
- `src/setup/install.ts` builds install targets, uses exclusive writes, and rolls back partial writes on failure.
- `src/setup/releases.ts` filters out draft and prerelease releases and paginates GitHub release results with `per_page=100`.
- README and consumer example docs now direct users to `npx --package=@git-vibe/app git-vibe-setup`.

## Tests
- Added setup CLI, installer, release-selection, rollback, and docs coverage in `tests/setup-cli.test.mjs` and `tests/docs.test.mjs`.
- Review-matrix handoff for issue #28 reports all three role reviews passed.
- `git diff --check origin/dev...HEAD` passed locally.
- `corepack pnpm check` was attempted but could not run because `node_modules` is missing and `prettier` is not available in this workspace.

## Risks
- Full local gate still needs to run in an environment with dependencies installed.
- Setup depends on the GitHub releases API being reachable; failure is surfaced before writing files.

Fixes #23
Addresses #28

## GitVibe Traceability

Refs #23
Refs #28