### PR TITLE
Add profile context files for AI prompts

### DIFF
--- a/.github/git-vibe.yml
+++ b/.github/git-vibe.yml
@@ -61,6 +61,9 @@ ai:
       enabled: true
       adapter: ai-sdk-agentool
       context_window_tokens: 200000
+      context:
+        files:
+          - AGENTS.md
       provider:
         type: openai-compatible
         model: kimi-k2.5

--- a/README.md
+++ b/README.md
@@ -350,6 +350,11 @@ ai:
           from_bundle: GITVIBE_AI_API_KEY
       reasoning:
         effort: high
+      # Optional explicit repo context. GitVibe does not auto-load AGENTS.md,
+      # CLAUDE.md, or other native CLI files.
+      # context:
+      #   files:
+      #     - AGENTS.md
   role_groups:
     review_gate:
       synthesizer: local_proxy
@@ -384,6 +389,10 @@ falling back to a profile name the repository may not have configured.
 Role definitions referenced by `role_group` live in `.git-vibe/role-group/*.md`.
 CLI adapters use fixed commands (`codex exec` and `claude -p`); profiles choose
 adapter, model, auth, env, and reasoning settings, not the executable command.
+Profiles may opt into shared repository guidance with
+`ai.profiles.<name>.context.files`. Listed files are appended to the rendered
+system prompt for that profile across `ai-sdk-agentool`, `cli-codex`, and
+`cli-claude-code`; GitVibe never auto-loads `AGENTS.md` or `CLAUDE.md`.
 
 Set `tests.commands` to the consumer repository's own verification gate, such as
 its lint, typecheck, unit test, or integration test commands.

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -174,6 +174,9 @@ ai:
       auth_json:
         from_bundle: CODEX_AUTH_JSON
       model: gpt-5.3-codex
+      context:
+        files:
+          - AGENTS.md
       reasoning:
         effort: high
         summary: concise
@@ -215,11 +218,21 @@ can inspect repository and GitHub context, and returns the same final stage
 schema that single-profile execution returns. `role_group` is allowed only for
 read-only stages: `investigate`, `validate`, and `review-matrix`.
 
+Profile context files are explicit per-profile system prompt additions. GitVibe
+does not auto-load `AGENTS.md`, `CLAUDE.md`, or Codex/Claude native context
+files. When `ai.profiles.<profile>.context.files` is configured, each listed
+workspace-relative file is appended to the system prompt inside a
+`<git_vibe_profile_context>` block for runs using that profile, including
+fallback retries, role-group members, and finalizers. Missing files, empty files,
+absolute paths, `..` traversal, symlinks, directories, and paths resolving
+outside the workspace fail fast.
+
 Normalized reasoning config:
 
 - `reasoning.effort`: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`. Adapters should reject unsupported values for the selected provider/model with a clear config error.
 - `reasoning.summary`: `auto`, `concise`, `detailed`, or `none` where the adapter supports summaries.
 - `context_window_tokens`: optional positive integer on an AI profile. When set, `ai-sdk-agentool` logs per-step `context_used_pct` from reported input tokens.
+- `context.files`: optional non-empty list of relative workspace files to append to this profile's system prompt.
 - `provider.api_key.from_bundle`: AI SDK provider API key inside `GITVIBE_AI_ENV_JSON`.
 - `provider.base_url.from_bundle`: AI SDK provider base URL inside `GITVIBE_AI_ENV_JSON`; required for OpenAI-compatible endpoints and optional for native OpenAI.
 - `env.<NAME>`: CLI-only environment mapping for spawned CLI processes. Use `{ from_bundle: KEY }` to read a key inside `GITVIBE_AI_ENV_JSON`, or a literal string for values intentionally committed in config.

--- a/packages/git-vibe-setup/templates/.github/git-vibe.yml
+++ b/packages/git-vibe-setup/templates/.github/git-vibe.yml
@@ -34,6 +34,11 @@ ai:
         temperature: 0.2
         max_output_tokens: 6000
         max_steps: 90
+      # Optional explicit repo context. GitVibe does not auto-load AGENTS.md,
+      # CLAUDE.md, or other native CLI files.
+      # context:
+      #   files:
+      #     - AGENTS.md
     codex_cli:
       enabled: false
       adapter: cli-codex
@@ -41,6 +46,9 @@ ai:
       auth_json:
         from_bundle: CODEX_AUTH_JSON
       model: gpt-5.3-codex
+      # context:
+      #   files:
+      #     - AGENTS.md
       reasoning:
         effort: high
         summary: concise
@@ -52,6 +60,9 @@ ai:
         CLAUDE_CODE_OAUTH_TOKEN:
           from_bundle: CLAUDE_OAUTH_TOKEN
       model: opus
+      # context:
+      #   files:
+      #     - .git-vibe/CLAUDE-extra.md
       reasoning:
         effort: xhigh
   role_groups:

--- a/src/runner/ai.ts
+++ b/src/runner/ai.ts
@@ -20,6 +20,7 @@ import { runCodexCliStage } from "./codex-cli.js";
 import { createRetryingFetch, retryDelayMsForHeaders } from "./ai-retry.js";
 import { logAiSdkAssistantStep, logAiSdkIoInput, logAiSdkIoOutput } from "./ai-sdk-io.js";
 import { createTools, stageToolNames } from "./ai-tools.js";
+import { systemWithProfileContext } from "./profile-context.js";
 import {
   extractValidatedOutput,
   outputValidatorContentFromSteps,
@@ -124,16 +125,25 @@ async function runAiStageWithProfile(
 ): Promise<string> {
   const profile = activeProfileByName(options.config, profileName);
   const adapter = adapterName(profile);
+  const profileOptions = {
+    ...options,
+    system: systemWithProfileContext({
+      cwd: options.cwd,
+      profile,
+      profileName,
+      system: options.system,
+    }),
+  };
   if (adapter === "cli-codex") {
     return runCodexCliStage({
-      options,
+      options: profileOptions,
       profile,
       profileName,
     });
   }
   if (adapter === "cli-claude-code") {
     return runClaudeCodeCliStage({
-      options,
+      options: profileOptions,
       profile,
       profileName,
     });
@@ -142,7 +152,7 @@ async function runAiStageWithProfile(
     throw new Error(`AI profile ${profileName} uses unsupported adapter ${adapter}.`);
   }
 
-  return runAiSdkStageWithProfile(options, profileName, profile);
+  return runAiSdkStageWithProfile(profileOptions, profileName, profile);
 }
 
 async function runAiSdkStageWithProfile(

--- a/src/runner/profile-context.ts
+++ b/src/runner/profile-context.ts
@@ -1,0 +1,126 @@
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, win32 } from "node:path";
+
+export function systemWithProfileContext(options: {
+  cwd: string;
+  profile: Record<string, unknown>;
+  profileName: string;
+  system: string;
+}): string {
+  const addition = profileContextSystemAddition(options);
+  return addition ? `${options.system}\n\n${addition}` : options.system;
+}
+
+export function profileContextSystemAddition(options: {
+  cwd: string;
+  profile: Record<string, unknown>;
+  profileName: string;
+}): string | null {
+  const files = profileContextFiles(options.profile, `ai.profiles.${options.profileName}.context`);
+  if (files.length === 0) return null;
+  return files
+    .map((file, index) =>
+      profileContextBlock({
+        content: readProfileContextFile({
+          cwd: options.cwd,
+          path: file,
+          sourcePath: `ai.profiles.${options.profileName}.context.files[${index}]`,
+        }),
+        path: file,
+        profileName: options.profileName,
+      }),
+    )
+    .join("\n\n");
+}
+
+function profileContextFiles(profile: Record<string, unknown>, sourcePath: string): string[] {
+  const context = profile.context;
+  if (context === undefined) return [];
+  if (!isRecord(context)) throw new Error(`${sourcePath} must be an object.`);
+
+  const files = context.files;
+  if (files === undefined) return [];
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error(`${sourcePath}.files must be a non-empty string array.`);
+  }
+
+  return files.map((file, index) => {
+    const value = stringValue(file);
+    if (!value) throw new Error(`${sourcePath}.files[${index}] must be a non-empty string.`);
+    assertRelativeWorkspacePath(value, `${sourcePath}.files[${index}]`);
+    return value;
+  });
+}
+
+function readProfileContextFile(options: {
+  cwd: string;
+  path: string;
+  sourcePath: string;
+}): string {
+  const filePath = join(options.cwd, options.path);
+  let fileInfo: ReturnType<typeof lstatSync>;
+  try {
+    fileInfo = lstatSync(filePath);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      throw new Error(
+        `Profile context file does not exist: ${options.sourcePath} (${options.path})`,
+      );
+    }
+    throw error;
+  }
+
+  if (fileInfo.isSymbolicLink() || !fileInfo.isFile()) {
+    throw new Error(`Profile context file must be a regular file: ${options.path}`);
+  }
+
+  const realCwd = realpathSync(options.cwd);
+  const realFilePath = realpathSync(filePath);
+  if (!isPathInside(realFilePath, realCwd)) {
+    throw new Error(`Profile context file must stay inside the workspace: ${options.path}`);
+  }
+
+  const content = readFileSync(filePath, "utf8").trim();
+  if (!content) throw new Error(`Profile context file must not be empty: ${options.path}`);
+  return content;
+}
+
+function profileContextBlock(options: {
+  content: string;
+  path: string;
+  profileName: string;
+}): string {
+  return `<git_vibe_profile_context profile="${xmlAttribute(options.profileName)}" path="${xmlAttribute(
+    options.path,
+  )}">
+${options.content}
+</git_vibe_profile_context>`;
+}
+
+function assertRelativeWorkspacePath(value: string, sourcePath: string): void {
+  const segments = value.split(/[\\/]+/);
+  if (value === "." || isAbsolute(value) || win32.isAbsolute(value) || segments.includes("..")) {
+    throw new Error(`${sourcePath} must be a relative path inside the workspace.`);
+  }
+}
+
+function isPathInside(filePath: string, rootPath: string): boolean {
+  const relativePath = relative(rootPath, filePath);
+  return relativePath !== "" && !relativePath.startsWith("..") && !isAbsolute(relativePath);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function xmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/tests/ai-profile-context.test.mjs
+++ b/tests/ai-profile-context.test.mjs
@@ -1,0 +1,266 @@
+// @ts-nocheck
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setImmediate } from "node:timers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const generateText = vi.fn();
+const createOpenAI = vi.fn(() => ({ chat: vi.fn(() => "openai-model") }));
+const createAnthropic = vi.fn(() => ({ languageModel: vi.fn(() => "anthropic-model") }));
+const spawn = vi.fn();
+const spawnedChildren = [];
+
+vi.mock("ai", () => ({
+  generateText,
+  hasToolCall: vi.fn((toolName) => ({ toolName })),
+  stepCountIs: vi.fn((count) => ({ count })),
+}));
+vi.mock("@ai-sdk/openai", () => ({ createOpenAI }));
+vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic }));
+vi.mock("node:child_process", () => ({ spawn }));
+
+const { runAiStage } = await import("../src/runner/ai.ts");
+const { stageDefinitions } = await import("../src/shared/stages.ts");
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  generateText.mockReset();
+  createOpenAI.mockClear();
+  createAnthropic.mockClear();
+  spawn.mockReset();
+  spawnedChildren.length = 0;
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  process.env = {
+    ...originalEnv,
+    GITVIBE_AI_ENV_JSON: JSON.stringify({
+      FALLBACK_BASE_URL: "https://fallback.test/v1",
+      FALLBACK_KEY: "fallback-key",
+      STAGE_BASE_URL: "https://stage.test/v1",
+      STAGE_KEY: "stage-key",
+    }),
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env = { ...originalEnv };
+});
+
+describe("AI profile context routing", () => {
+  it("adds context files configured on the active AI SDK profile to the system prompt", async () => {
+    const cwd = contextWorkspace({ "PROFILE.md": "Use profile-specific repository guidance." });
+    const config = stageRoutingConfig();
+    config.ai.profiles.validation_profile.context = { files: ["PROFILE.md"] };
+    generateText.mockResolvedValueOnce(aiResult("validate"));
+
+    try {
+      await expect(
+        runAiStage({
+          ...validateStageOptions(config),
+          cwd,
+        }),
+      ).resolves.toBe('{"stage":"validate","status":"completed"}');
+
+      expect(generateText.mock.calls[0][0].system).toContain(
+        '<git_vibe_profile_context profile="validation_profile" path="PROFILE.md">',
+      );
+      expect(generateText.mock.calls[0][0].system).toContain(
+        "Use profile-specific repository guidance.",
+      );
+      expect(generateText.mock.calls[0][0].prompt).toBe("Prompt");
+    } finally {
+      cleanupWorkspace(cwd);
+    }
+  });
+
+  it("uses context files from the fallback profile when retrying", async () => {
+    const cwd = contextWorkspace({ "FALLBACK.md": "Fallback profile guidance." });
+    const config = fallbackRoutingConfig();
+    config.ai.profiles.fallback.context = { files: ["FALLBACK.md"] };
+    generateText.mockResolvedValueOnce(aiResult("investigate"));
+
+    try {
+      await expect(
+        runAiStage({
+          config,
+          cwd,
+          maxTurns: 1,
+          prompt: "Prompt",
+          schema: {},
+          schemaId: "schema",
+          stage: "investigate",
+          stageDefinition: stageDefinitions.investigate,
+          system: "System",
+        }),
+      ).resolves.toBe('{"stage":"investigate","status":"completed"}');
+
+      expect(generateText.mock.calls[0][0].system).toContain(
+        '<git_vibe_profile_context profile="fallback" path="FALLBACK.md">',
+      );
+      expect(generateText.mock.calls[0][0].system).toContain("Fallback profile guidance.");
+    } finally {
+      cleanupWorkspace(cwd);
+    }
+  });
+
+  it("adds context files configured on Codex CLI profiles to stdin", async () => {
+    const cwd = contextWorkspace({ "AGENTS.md": "Codex profile guidance." });
+    mockCodexOutput('{"stage":"validate","status":"completed"}');
+
+    try {
+      await expect(
+        runAiStage({
+          ...validateStageOptions({
+            ai: {
+              profiles: {
+                codex_cli: {
+                  adapter: "cli-codex",
+                  context: { files: ["AGENTS.md"] },
+                  model: "codex-test-model",
+                },
+              },
+              stages: {
+                validate: {
+                  profile: "codex_cli",
+                },
+              },
+            },
+          }),
+          cwd,
+        }),
+      ).resolves.toBe('{"stage":"validate","status":"completed"}');
+
+      expect(spawnedChildren[0].stdin.end).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '<git_vibe_profile_context profile="codex_cli" path="AGENTS.md">\nCodex profile guidance.',
+        ),
+      );
+    } finally {
+      cleanupWorkspace(cwd);
+    }
+  });
+});
+
+function validateStageOptions(config) {
+  return {
+    config,
+    cwd: process.cwd(),
+    maxTurns: 1,
+    prompt: "Prompt",
+    schema: {},
+    schemaId: "schema",
+    stage: "validate",
+    stageDefinition: stageDefinitions.validate,
+    system: "System",
+  };
+}
+
+function stageRoutingConfig() {
+  return {
+    ai: {
+      profiles: {
+        validation_profile: {
+          generation: { temperature: 0.1 },
+          provider: {
+            api_key: { from_bundle: "STAGE_KEY" },
+            base_url: { from_bundle: "STAGE_BASE_URL" },
+            model: "stage-model",
+            type: "openai-compatible",
+          },
+        },
+      },
+      stages: {
+        validate: {
+          profile: "validation_profile",
+          tools: ["read"],
+        },
+      },
+    },
+  };
+}
+
+function fallbackRoutingConfig() {
+  return {
+    ai: {
+      profiles: {
+        fallback: {
+          provider: {
+            api_key: { from_bundle: "FALLBACK_KEY" },
+            base_url: { from_bundle: "FALLBACK_BASE_URL" },
+            model: "fallback-model",
+            type: "openai-compatible",
+          },
+        },
+        primary: {
+          provider: {
+            api_key: { from_bundle: "PRIMARY_KEY" },
+            base_url: { from_bundle: "PRIMARY_BASE_URL" },
+            model: "primary-model",
+            type: "openai-compatible",
+          },
+        },
+      },
+      stages: {
+        investigate: {
+          fallback_profile: "fallback",
+          profile: "primary",
+        },
+      },
+    },
+  };
+}
+
+function mockCodexOutput(content) {
+  spawn.mockImplementationOnce((_command, args) =>
+    mockChildProcess({
+      onInput: () => writeFileSync(outputPathFrom(args), content),
+      stdout: "codex event\n",
+    }),
+  );
+}
+
+function mockChildProcess({ exitCode = 0, onInput, stderr = "", stdout = "" }) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = {
+    end: vi.fn((input) => {
+      onInput?.(input);
+      setImmediate(() => {
+        if (stdout) child.stdout.emit("data", Buffer.from(stdout));
+        if (stderr) child.stderr.emit("data", Buffer.from(stderr));
+        child.emit("close", exitCode, null);
+      });
+    }),
+  };
+  spawnedChildren.push(child);
+  return child;
+}
+
+function outputPathFrom(args) {
+  return args[args.indexOf("--output-last-message") + 1];
+}
+
+function aiResult(stage) {
+  const content = JSON.stringify({ stage, status: "completed" });
+  return {
+    steps: [{ toolCalls: [{ input: { content }, toolName: "output_validator" }] }],
+    text: content,
+  };
+}
+
+function contextWorkspace(files) {
+  const cwd = mkdtempSync(join(tmpdir(), "git-vibe-ai-profile-context-"));
+  for (const [path, content] of Object.entries(files)) {
+    writeFileSync(join(cwd, path), content);
+  }
+  return cwd;
+}
+
+function cleanupWorkspace(cwd) {
+  rmSync(cwd, { force: true, recursive: true });
+}

--- a/tests/claude-code-cli.test.mjs
+++ b/tests/claude-code-cli.test.mjs
@@ -1,5 +1,8 @@
 // @ts-nocheck
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { setImmediate } from "node:timers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -134,6 +137,38 @@ describe("Claude Code CLI adapter", () => {
     );
 
     expect(spawn).not.toHaveBeenCalled();
+  });
+});
+
+describe("Claude Code CLI profile context", () => {
+  it("adds context files configured on Claude Code profiles to the system prompt", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "git-vibe-claude-context-"));
+    writeFileSync(join(cwd, "CLAUDE-extra.md"), "Claude profile guidance.");
+    const config = claudeCodeConfig();
+    config.ai.profiles.claude_code.context = { files: ["CLAUDE-extra.md"] };
+    mockReadableClaudeStream({
+      is_error: false,
+      structured_output: { stage: "validate", status: "completed" },
+      type: "result",
+    });
+
+    try {
+      await expect(
+        runAiStage({
+          ...validateStageOptions(config),
+          cwd,
+        }),
+      ).resolves.toBe('{"stage":"validate","status":"completed"}');
+
+      const args = spawn.mock.calls[0][1];
+      const systemPrompt = args[args.indexOf("--system-prompt") + 1];
+      expect(systemPrompt).toContain(
+        '<git_vibe_profile_context profile="claude_code" path="CLAUDE-extra.md">',
+      );
+      expect(systemPrompt).toContain("Claude profile guidance.");
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
   });
 });
 

--- a/tests/profile-context.test.mjs
+++ b/tests/profile-context.test.mjs
@@ -1,0 +1,164 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  profileContextSystemAddition,
+  systemWithProfileContext,
+} from "../src/runner/profile-context.ts";
+
+describe("profile context system additions", () => {
+  it("omits profile context when a profile does not configure files", () => {
+    expect(
+      systemWithProfileContext({
+        cwd: process.cwd(),
+        profile: {},
+        profileName: "local_proxy",
+        system: "System",
+      }),
+    ).toBe("System");
+  });
+
+  it("renders configured files in order with profile and path metadata", () => {
+    const cwd = contextWorkspace({
+      "AGENTS.md": "Follow repository rules.",
+      'docs/repo "guide".md': "Prefer existing helpers.",
+    });
+
+    try {
+      const addition = profileContextSystemAddition({
+        cwd,
+        profile: { context: { files: ["AGENTS.md", 'docs/repo "guide".md'] } },
+        profileName: "codex&cli",
+      });
+      expect(addition).not.toBeNull();
+      const rendered = /** @type {string} */ (addition);
+
+      expect(rendered).toContain(
+        '<git_vibe_profile_context profile="codex&amp;cli" path="AGENTS.md">',
+      );
+      expect(rendered).toContain("Follow repository rules.");
+      expect(rendered).toContain('path="docs/repo &quot;guide&quot;.md"');
+      expect(rendered).toContain("Prefer existing helpers.");
+      expect(rendered.indexOf("Follow repository rules.")).toBeLessThan(
+        rendered.indexOf("Prefer existing helpers."),
+      );
+    } finally {
+      cleanupWorkspace(cwd);
+    }
+  });
+});
+
+describe("profile context config validation", () => {
+  it("rejects malformed profile context config", () => {
+    expect(() =>
+      profileContextSystemAddition({
+        cwd: process.cwd(),
+        profile: { context: [] },
+        profileName: "local_proxy",
+      }),
+    ).toThrow("ai.profiles.local_proxy.context must be an object.");
+    expect(() =>
+      profileContextSystemAddition({
+        cwd: process.cwd(),
+        profile: { context: { files: [] } },
+        profileName: "local_proxy",
+      }),
+    ).toThrow("ai.profiles.local_proxy.context.files must be a non-empty string array.");
+    expect(() =>
+      profileContextSystemAddition({
+        cwd: process.cwd(),
+        profile: { context: { files: [""] } },
+        profileName: "local_proxy",
+      }),
+    ).toThrow("ai.profiles.local_proxy.context.files[0] must be a non-empty string.");
+  });
+
+  it("rejects unsafe profile context paths before reading files", () => {
+    const cwd = contextWorkspace({});
+
+    try {
+      for (const path of ["/etc/passwd", "../AGENTS.md", "docs/../AGENTS.md", "C:\\secrets.md"]) {
+        expect(() =>
+          profileContextSystemAddition({
+            cwd,
+            profile: { context: { files: [path] } },
+            profileName: "local_proxy",
+          }),
+        ).toThrow("must be a relative path inside the workspace");
+      }
+    } finally {
+      cleanupWorkspace(cwd);
+    }
+  });
+
+  it("fails fast for missing and empty configured files", () => {
+    const cwd = contextWorkspace({ "EMPTY.md": "  \n" });
+
+    try {
+      expect(() =>
+        profileContextSystemAddition({
+          cwd,
+          profile: { context: { files: ["MISSING.md"] } },
+          profileName: "local_proxy",
+        }),
+      ).toThrow("Profile context file does not exist");
+      expect(() =>
+        profileContextSystemAddition({
+          cwd,
+          profile: { context: { files: ["EMPTY.md"] } },
+          profileName: "local_proxy",
+        }),
+      ).toThrow("Profile context file must not be empty");
+    } finally {
+      cleanupWorkspace(cwd);
+    }
+  });
+
+  it("rejects symlinks and files that resolve outside the workspace", () => {
+    const cwd = contextWorkspace({});
+    const outside = contextWorkspace({ "context.md": "external host content" });
+
+    try {
+      symlinkSync(join(outside, "context.md"), join(cwd, "linked-file.md"));
+      symlinkSync(outside, join(cwd, "linked-dir"), "dir");
+
+      expect(() =>
+        profileContextSystemAddition({
+          cwd,
+          profile: { context: { files: ["linked-file.md"] } },
+          profileName: "local_proxy",
+        }),
+      ).toThrow("Profile context file must be a regular file");
+      expect(() =>
+        profileContextSystemAddition({
+          cwd,
+          profile: { context: { files: ["linked-dir/context.md"] } },
+          profileName: "local_proxy",
+        }),
+      ).toThrow("Profile context file must stay inside the workspace");
+    } finally {
+      cleanupWorkspace(cwd);
+      cleanupWorkspace(outside);
+    }
+  });
+});
+
+/**
+ * @param {Record<string, string>} files
+ */
+function contextWorkspace(files) {
+  const cwd = mkdtempSync(join(tmpdir(), "git-vibe-profile-context-"));
+  for (const [path, content] of Object.entries(files)) {
+    mkdirSync(join(cwd, path, ".."), { recursive: true });
+    writeFileSync(join(cwd, path), content);
+  }
+  return cwd;
+}
+
+/**
+ * @param {string} cwd
+ */
+function cleanupWorkspace(cwd) {
+  rmSync(cwd, { force: true, recursive: true });
+}

--- a/tests/stage-runner-matrix.test.mjs
+++ b/tests/stage-runner-matrix.test.mjs
@@ -128,6 +128,39 @@ describe("stage runner matrix member execution", () => {
   });
 });
 
+describe("stage runner matrix member profile context", () => {
+  it("passes member profile context alongside the role definition", async () => {
+    const cwd = await workspace(profileConfigWithContext());
+    writeRole(cwd, "security.md", "Focus on token boundaries.");
+    writeFileSync(join(cwd, "PROFILE.md"), "Member profile guidance.");
+    generateText.mockResolvedValueOnce(aiResult("validate"));
+    globalThis.fetch = fetchMock([issueResponse(), commentsResponse([])]);
+
+    const result = await runStage({
+      cwd,
+      dryRun: false,
+      executionMode: "member",
+      issueNumber: "12",
+      maxTurns: 2,
+      prNumber: "",
+      profileName: "test",
+      repository: "example/repo",
+      roleName: "security.md",
+      stage: "validate",
+      stageTimeoutMinutes: 1,
+      token: "token",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(generateText.mock.calls[0][0].system).toContain(
+      '<git_vibe_profile_context profile="test" path="PROFILE.md">',
+    );
+    expect(generateText.mock.calls[0][0].system).toContain("Member profile guidance.");
+    expect(generateText.mock.calls[0][0].system).toContain("<git_vibe_role_definition>");
+    expect(generateText.mock.calls[0][0].system).toContain("Focus on token boundaries.");
+  });
+});
+
 describe("stage runner matrix finalizer execution", () => {
   it("passes through single-profile member output during finalization", async () => {
     const cwd = await workspace(profileConfig());
@@ -193,8 +226,9 @@ describe("stage runner matrix finalizer execution", () => {
 
 describe("stage runner matrix finalizer synthesis", () => {
   it("synthesizes role-group member outputs into one final stage result", async () => {
-    const cwd = await workspace(roleGroupConfig("validate"));
+    const cwd = await workspace(roleGroupConfigWithContext("validate"));
     writeRole(cwd, "security.md", "Focus on token boundaries.");
+    writeFileSync(join(cwd, "PROFILE.md"), "Synthesizer profile guidance.");
     const resultsDir = join(cwd, "member-results");
     mkdirSync(resultsDir);
     writeFileSync(join(resultsDir, "git-vibe-validate-result.json"), memberResult("validate"));
@@ -230,6 +264,10 @@ describe("stage runner matrix finalizer synthesis", () => {
     expect(generateText.mock.calls[0][0].system).toContain(
       "Inspect the repository and GitHub context",
     );
+    expect(generateText.mock.calls[0][0].system).toContain(
+      '<git_vibe_profile_context profile="test" path="PROFILE.md">',
+    );
+    expect(generateText.mock.calls[0][0].system).toContain("Synthesizer profile guidance.");
   });
 });
 
@@ -258,12 +296,42 @@ function profileConfig() {
   ].join("\n");
 }
 
+function profileConfigWithContext() {
+  return [
+    "ai:",
+    "  profiles:",
+    "    test:",
+    profileYamlWithContext(),
+    "  stages:",
+    "    review-matrix:",
+    "      profile: test",
+  ].join("\n");
+}
+
 function roleGroupConfig(stage = "review-matrix") {
   return [
     "ai:",
     "  profiles:",
     "    test:",
     profileYaml(),
+    "  role_groups:",
+    "    review_gate:",
+    "      synthesizer: test",
+    "      roles:",
+    "        - role: security.md",
+    "          profile: test",
+    "  stages:",
+    `    ${stage}:`,
+    "      role_group: review_gate",
+  ].join("\n");
+}
+
+function roleGroupConfigWithContext(stage = "review-matrix") {
+  return [
+    "ai:",
+    "  profiles:",
+    "    test:",
+    profileYamlWithContext(),
     "  role_groups:",
     "    review_gate:",
     "      synthesizer: test",
@@ -286,6 +354,10 @@ function profileYaml() {
     "        api_key:",
     "          from_bundle: GITVIBE_AI_API_KEY",
   ].join("\n");
+}
+
+function profileYamlWithContext() {
+  return [profileYaml(), "      context:", "        files:", "          - PROFILE.md"].join("\n");
 }
 
 function memberResult(stage = "review-matrix") {


### PR DESCRIPTION
## Summary
- Add per-profile context.files support that appends validated repository context files to the active system prompt.
- Apply profile context across AI SDK, Codex CLI, Claude Code CLI, fallback profiles, role-group members, and finalizers.
- Document explicit opt-in behavior and update setup examples.

## Tests
- corepack pnpm check