### PR TITLE
Prepare git-vibe-setup v3 release

### DIFF
--- a/.github/workflows/automatic-pr-review.yml
+++ b/.github/workflows/automatic-pr-review.yml
@@ -1,14 +1,15 @@
-name: GitVibe review dev PR
-run-name: "[git-vibe][review-dev]: PR #${{ github.event.pull_request.number }}"
+name: GitVibe automatic PR review
+run-name: "[git-vibe][automatic-pr-review]: PR #${{ github.event.pull_request.number }}"
 
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
     branches:
+      - main
       - dev
 
 concurrency:
-  group: git-vibe-review-dev-pr-${{ github.event.pull_request.number }}
+  group: git-vibe-automatic-pr-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/review-dev-pr.yml
+++ b/.github/workflows/review-dev-pr.yml
@@ -3,12 +3,12 @@ run-name: "[git-vibe][review-dev]: PR #${{ github.event.pull_request.number }}"
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
     branches:
       - dev
 
 concurrency:
-  group: git-vibe-review-${{ github.event.pull_request.number }}
+  group: git-vibe-review-dev-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -2,7 +2,9 @@
 
 ## Context Assembly And Analysis
 
-All investigation, validation, decomposition, materialization, and refinement runs must build context from the full GitHub conversation, not just the initial description.
+All investigation, validation, materialization, implementation, review, and PR
+feedback remediation runs must build context from the full GitHub conversation,
+not just the initial description.
 
 ```mermaid
 flowchart TD
@@ -12,7 +14,7 @@ flowchart TD
   D --> E[Attach parent/thread references]
   E --> F[Classify author authority]
   F --> G[Weighted analysis prompt]
-  G --> H[Questions, validation, decomposition, or implementation brief]
+  G --> H[Questions, validation, materialization, implementation, review, or feedback brief]
 ```
 
 Context assembly rules:
@@ -27,7 +29,9 @@ Context assembly rules:
 - Weight analysis by authority: admin/owner/maintain > write/collaborator/member > contributor > first-time contributor/guest/none.
 - When repository permission and `author_association` disagree, repository permission is stronger for approval and command authorization; `author_association` remains useful analysis metadata.
 
-The same context assembly and weighted analysis pipeline applies to bug investigation, feature discussion validation, decomposition, materialization, and PR feedback handling.
+The same context assembly and weighted analysis pipeline applies to bug
+investigation, feature discussion validation, materialization, implementation,
+review, and PR feedback handling.
 
 ## Stage Contracts
 
@@ -35,12 +39,12 @@ GitVibe should treat AI as a set of stage-specific workers behind stable contrac
 
 ```mermaid
 flowchart TD
-  A[GitHub event or scheduled scan] --> B[Orchestrator]
+  A[GitHub webhook or workflow dispatch] --> B[Orchestrator]
   B --> C[Build context packet]
   C --> D[Select stage contract]
-  D --> E[Plan profile or role-group matrix]
-  E --> F[Run member AI job or jobs]
-  F --> G[Finalizer validates one structured result]
+  D --> E[Select profile or role-group plan]
+  E --> F[Run AI job or role-group member jobs]
+  F --> G[Validate one structured result]
   G --> H{Policy gate}
   H -->|allowed| I[Post comment, update labels, dispatch next workflow, or push branch]
   H -->|blocked| J[Post explanation and wait for human context]
@@ -50,24 +54,29 @@ AI integration layers:
 
 - Orchestrator: deterministic code that validates actor permissions, reads config, builds context, enforces stage gates, and writes GitHub state.
 - Context builder: gathers issue/discussion/PR timelines, repo snapshots, relevant files, reactions, workflow history, and linked artifacts into a stage-specific context packet.
-- Stage contracts: typed task definitions for investigation, refinement, validation, implementation, review, and feedback remediation.
+- Stage contracts: typed task definitions for investigation, validation,
+  materialization, implementation, pull request creation, review, and feedback
+  remediation.
 - AI adapter: `ai-sdk-agentool` is the primary adapter for all AI SDK-backed work. Structured-only stages use the same adapter with no tools or read-only tools.
 - CLI adapters: `cli-codex` and `cli-claude-code` run fixed non-interactive CLI commands, stream CLI output to the action log, and parse structured output.
-- External mention adapter: optional GitHub-visible comments to Codex, Claude, Copilot, or similar apps.
+- External mention adapter: not currently implemented; the shipped config keeps
+  `commands.allow_external_agent_mentions` disabled.
 - Result validator: checks that AI output matches the stage schema, references the supplied context, and does not request disallowed actions.
 
-Initial stage contracts:
+Implemented stage contracts:
 
-| Stage                   | Repository scope                     | Output                                                                                  | May advance state                                                 |
-| ----------------------- | ------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Triage classification   | Issue/discussion context             | Suggested type, labels, confidence, missing info                                        | No, except safe labels if configured                              |
-| Bug investigation       | Repo snapshot and issue timeline     | Findings, suspected areas, blocking questions, concrete implementation plan             | No code changes                                                   |
-| Feature validation      | Repo snapshot and discussion thread  | Findings, contradictions, open questions, and readiness decision                        | May mark ready for materialization only if policy allows          |
-| Materialization         | Accepted validated discussion        | Implementation issue drafts with dependencies, acceptance criteria, and review guidance | May create labeled implementation issues                          |
-| Validation              | Repo snapshot and accepted context   | Pass/fail, contradictions, implementation brief                                         | May mark ready only if policy allows                              |
-| Implementation          | `git-vibe/{root-issue}` branch       | Commits, test output, implementation summary                                            | Uses branch-update engine; may update issue branch, not merge     |
-| Review matrix           | Pull request diff and review context | Findings by reviewer role, pass/fail, required fixes, optional inline PR comments       | May mark a PR ready or blocked, and may queue PR feedback retries |
-| PR feedback remediation | Existing PR branch                   | Fix commits or skipped-comment rationale                                                | Uses branch-update engine; may update PR branch, not create PR    |
+| Stage                 | Schema                   | Repository scope                        | Output                                                                           | May advance state                                                |
+| --------------------- | ------------------------ | --------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `investigate`         | `investigate.v1`         | Issue timeline, or PR feedback context  | Findings, blocking questions, implementation plan, or PR feedback classification | May mark issue investigated/blocked or PR feedback state         |
+| `validate`            | `validate.v1`            | Issue or Discussion context             | Readiness decision, contradictions, questions, implementation brief              | May mark issue ready for approval or Discussion validated        |
+| `materialize`         | `materialize.v2`         | Accepted validated Discussion           | One or more implementation issue drafts with dependencies and review guidance    | Creates `gvi:story` implementation issues and closes source      |
+| `implement`           | `implement.v1`           | `git-vibe/{root-issue}` issue branch    | Working tree changes, test rationale, implementation summary                     | Uses branch-update engine; may commit and push issue branch      |
+| `create-pr`           | `create-pr.v1`           | GitVibe issue branch                    | Pull request title and body                                                      | Creates or updates the PR and marks source issue `gvi:pr-opened` |
+| `review-matrix`       | `review-matrix.v1`       | Pull request diff and review context    | Evidence-backed findings, pass/fail result, optional inline PR comments          | May mark a PR ready or blocked, and may queue feedback retries   |
+| `address-pr-feedback` | `address-pr-feedback.v1` | Existing same-repository PR head branch | Fix commits or skipped-feedback rationale                                        | Uses branch-update engine; may update PR branch, not create PR   |
+
+There is no standalone `decompose` stage. Splitting accepted scope into
+multiple implementation issues happens inside `materialize`.
 
 AI result envelope:
 
@@ -131,7 +140,9 @@ Rules:
 - Provider execution uses `ai-sdk-agentool` with Vercel AI SDK, `agentool` 1.5.x, provider SDKs, and Zod schemas.
 - Provider support should include OpenAI, Anthropic, and OpenAI-compatible custom endpoints through the same config shape.
 - Additional providers should be added behind the same adapter contract, not by changing workflow stages.
-- External apps such as Codex, Claude, and Copilot are mention partners. GitVibe may invoke them with configured comments and ingest their visible replies, but GitVibe should not depend on private third-party state or assume they respond to bot mentions.
+- External apps such as Codex, Claude, and Copilot are not active workflow
+  dispatch paths in the current implementation. GitVibe should not depend on
+  private third-party state or assume they respond to bot mentions.
 - Local/self-hosted model support can use the same adapter interface when operators provide an endpoint and credentials.
 
 CLI authentication guidance:
@@ -253,11 +264,15 @@ AI SDK tool policy by stage:
 
 Stage `tools` config is optional and only applies to the `ai-sdk-agentool` adapter. When omitted, GitVibe uses the built-in defaults below. CLI adapters do not receive these tool lists because their native agents own tool selection.
 
-- triage: no tools, GitHub context only.
-- investigation/refinement/validation: read, grep, glob, GitHub-only project search, and read-only `agent` subagents; website fetch/search is disabled by default.
-- implementation: read, grep, glob, edit, write, multi-edit, bash, diff.
-- review: read, grep, glob, diff, and read-only `agent` subagents.
-- PR feedback remediation: implementation tools scoped to the existing PR branch.
+- `investigate`: read, grep, glob, diff, GitHub search, optional web
+  fetch/search after domain allowlisting, and read-only `agent` subagents.
+- `validate`: read, grep, glob, GitHub search, optional web fetch/search after
+  domain allowlisting, and read-only `agent` subagents.
+- `materialize`: read, grep, and glob.
+- `implement`: read, grep, glob, edit, write, multi-edit, bash, and diff.
+- `create-pr`: read, grep, glob, and diff.
+- `review-matrix`: read, grep, glob, diff, and read-only `agent` subagents.
+- `address-pr-feedback`: implementation tools scoped to the existing PR branch.
 
 The `agent` tool is available only to read-only stages (`investigate`, `validate`,
 and `review-matrix`). GitVibe configures child agents with read-only tools and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@ jobs:
     uses: markhuangai/git-vibe/.github/workflows/develop.yml@v3
 ```
 
-Consumer repositories can run jobs on GitHub-hosted runners or self-hosted runners. The GitVibe orchestrator is hosted by the repository owner, receives or polls GitHub events, validates permissions, updates GitHub-native state, and dispatches workflows with parameters.
+Consumer repositories can run jobs on GitHub-hosted runners or self-hosted runners. The current GitVibe orchestrator is hosted by the repository owner, receives GitHub repository webhooks at `/webhooks`, validates permissions, updates GitHub-native state, and dispatches workflows with parameters.
 
 ## Runtime Boundaries
 
@@ -37,10 +37,10 @@ flowchart LR
   U[Guest or contributor] --> GH[GitHub issues, discussions, and PRs]
   M[Admin or collaborator] --> GH
 
-  GH -->|webhooks, relay, workflow events, or polling| APP[Self-hosted GitVibe Orchestrator]
+  GH -->|repository webhooks| APP[Self-hosted GitVibe Orchestrator]
   APP -->|validate actor permissions| GH
   APP -->|labels, comments, backlinks, markers| GH
-  APP -->|workflow_dispatch or repository_dispatch| WF[Consumer repo workflow]
+  APP -->|workflow_dispatch| WF[Consumer repo workflow]
 
   WF -->|uses| GV[markhuangai/git-vibe]
   WF --> RUNNER[GitHub-hosted or self-hosted runner]
@@ -49,8 +49,6 @@ flowchart LR
   RUNNER --> CODE[Repository checkout]
   RUNNER -->|branch, commits, PR, comments| GH
 
-  APP -. optional approved mentions .-> EXT[Codex, Claude, Copilot]
-  EXT -. visible replies and reviews .-> GH
 ```
 
 ## Webhook And Token Model
@@ -70,7 +68,7 @@ sequenceDiagram
   App->>API: Add label, comment, or state marker
   App->>API: Dispatch workflow with target parameters and run details request
   GH->>WF: Start workflow run
-  WF->>Act: Plan stage matrix, run member job(s), then finalizer
+  WF->>Act: Run stage job, or plan members plus finalizer for role-group stages
   Act->>API: Use configured repository PAT for branch, PR, comments, and metadata writes
 ```
 
@@ -87,7 +85,12 @@ Supported workflow auth modes:
 
 ## Event Delivery Modes
 
-Repository webhooks are the production event source when the operator has a reachable HTTPS endpoint. GitHub does not provide a first-party persistent stream where a private client dials out to subscribe to all repository events. GitVibe must therefore support several delivery modes.
+Repository webhooks are the implemented production event source when the operator has a reachable HTTPS endpoint. GitHub does not provide a first-party persistent stream where a private client dials out to subscribe to all repository events.
+
+The repository still ships the `event_delivery` config shape used by examples
+and future planning, but the current server code implements direct webhook
+delivery only. Relay, actions-native receiver, and polling modes are not active
+code paths.
 
 ```mermaid
 flowchart TD
@@ -97,23 +100,23 @@ flowchart TD
   GH --> D[Polling mode]
 
   A --> O[GitVibe orchestrator]
-  B --> O
-  C --> W[GitHub Actions receiver workflow]
-  D --> O
+  B -. planned .-> O
+  C -. planned .-> W[GitHub Actions receiver workflow]
+  D -. planned .-> O
 
   W --> O2[GitVibe action logic in runner]
   O --> API[GitHub API and workflow dispatch]
   O2 --> API
 ```
 
-Supported modes:
+Implemented and planned modes:
 
-- `webhook`: production default and first implemented mode. GitHub sends repository webhooks to a public HTTPS URL owned by the operator.
-- `relay`: deferred no-domain operator mode. GitHub sends webhooks to a relay such as Smee, Hookdeck, Cloudflare Tunnel, ngrok, or a self-hosted relay; the local GitVibe process keeps an outbound connection to receive events.
-- `actions`: deferred no-server mode. Consumer repositories install lightweight receiver workflows triggered by GitHub events and scheduled scans.
-- `polling`: deferred lowest-infrastructure mode. A local or scheduled GitVibe worker periodically queries issues, discussions, comments, reactions, labels, and workflow runs using ETags/cursors.
+- `webhook`: implemented mode. GitHub sends repository webhooks to a public HTTPS URL owned by the operator.
+- `relay`: planned no-domain operator mode. GitHub would send webhooks to a relay such as Smee, Hookdeck, Cloudflare Tunnel, ngrok, or a self-hosted relay; the local GitVibe process would keep an outbound connection to receive events.
+- `actions`: planned no-server mode. Consumer repositories would install lightweight receiver workflows triggered by GitHub events and scheduled scans.
+- `polling`: planned lowest-infrastructure mode. A local or scheduled GitVibe worker would periodically query issues, discussions, comments, reactions, labels, and workflow runs using ETags/cursors.
 
-Recommended defaults:
+Planned defaults:
 
 - Managed or organization deployment: `webhook`.
 - Local development: `relay` with Smee or an equivalent tunnel.
@@ -186,7 +189,8 @@ Required repository or organization secrets/variables:
 - `GITVIBE_GITHUB_TOKEN`: fine-grained PAT used by the server and workflows for GitHub API access.
 - `WEBHOOK_SECRET`: repository webhook shared secret used by the deploy workflow to set runtime `GITHUB_WEBHOOK_SECRET`.
 - `GITVIBE_AI_ENV_JSON`: JSON bundle for AI provider auth, endpoints, CLI auth, and provider-specific environment values.
-- `GITVIBE_DISCUSSION_CATEGORY`, `GITVIBE_RUNNER`, `GITVIBE_LOG_LEVEL`: optional variables.
+- `GITVIBE_DISCUSSION_CATEGORY`: optional variable used by app deployment for feature Discussion conversion category.
+- `GITVIBE_BASE_BRANCH`: optional variable used by reusable workflows as the implementation and review base branch.
 
 Self-hosted server runtime secrets:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,11 +13,16 @@
 - `.github/workflows/materialize.yml`: reusable Discussion-to-issue materialization pipeline.
 - `.github/workflows/develop.yml`: reusable issue development pipeline that implements, creates or updates a PR, then reviews it.
 - `.github/workflows/review.yml`: reusable pull request review pipeline.
+- `.github/workflows/review-dev-pr.yml`: repository-local `pull_request_target` wrapper that reviews non-draft PRs opened against `dev`.
 - `.github/workflows/address-feedback.yml`: reusable PR feedback pipeline that updates the existing PR branch before review when fixes are required.
+- `.github/workflows/ci.yml`: PR quality gate plus manual dispatch for format, lint, coverage, build, actionlint, and production audit.
+- `.github/workflows/app-deploy.yml`: app image build and deployment workflow for app/shared runtime changes on `dev`.
 - `.github/workflows/release.yml`: admin-only manual release workflow that runs from `main`, creates GitHub releases, and promotes the existing GHCR app image to the release tag.
 - Reusable GitVibe workflows also support `workflow_dispatch` for source-repo testing. Direct dispatch defaults the action source to the current repository/ref, while `workflow_call` defaults to the pinned `markhuangai/git-vibe@v3` release.
 - `.github/workflows/ai-smoke.yml`: manual repo-local smoke test for self-hosted AI runner setup.
-- `investigate/`, `implement/`, `review-matrix/`, `create-pr`, `address-pr-feedback/`: public composite action entry points.
+- `investigate/`, `validate/`, `materialize/`, `implement/`, `create-pr/`,
+  `review-matrix/`, `address-pr-feedback/`, `plan-stage/`, and
+  `mark-blocked/`: composite action entry points.
 - `src/app/server.ts`: self-hosted repository webhook server source.
 - `src/runner/actions/run-action.ts`: single-stage runner entry point built by composite actions before execution.
 - `src/runner`: config loading, context assembly, prompt rendering, schema validation, stage execution, shared branch-update writes, result publishing, and `ai-sdk-agentool` integration.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,7 +13,7 @@
 - `.github/workflows/materialize.yml`: reusable Discussion-to-issue materialization pipeline.
 - `.github/workflows/develop.yml`: reusable issue development pipeline that implements, creates or updates a PR, then reviews it.
 - `.github/workflows/review.yml`: reusable pull request review pipeline.
-- `.github/workflows/review-dev-pr.yml`: repository-local `pull_request_target` wrapper that reviews non-draft PRs opened against `dev`.
+- `.github/workflows/automatic-pr-review.yml`: repository-local `pull_request_target` wrapper that reviews non-draft PRs opened against `main` or `dev`.
 - `.github/workflows/address-feedback.yml`: reusable PR feedback pipeline that updates the existing PR branch before review when fixes are required.
 - `.github/workflows/ci.yml`: PR quality gate plus manual dispatch for format, lint, coverage, build, actionlint, and production audit.
 - `.github/workflows/app-deploy.yml`: app image build and deployment workflow for app/shared runtime changes on `dev`.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -31,7 +31,7 @@ Core defaults:
 
 - `/git-vibe ...` is the public command form for command-triggered workflows.
 - Bugs are investigated before any implementation approval.
-- Feature requests start in discussions and are materialized into issues only after refinement and protected approval.
+- Feature requests start in discussions and are materialized into issues only after validation and protected approval.
 - Development automation can be disabled with `ai.stages.implement.enabled: false`; PR review remains separately triggerable through `review.yml` and `git-vibe:review`.
 - Issue implementation and PR feedback remediation share runner-level
   branch-update mechanics, while `develop.yml` and `address-feedback.yml` stay

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -16,8 +16,7 @@ flowchart TD
   Route --> Feature[Feature or story]
   Feature --> Discuss[Discussion]
   Discuss --> Validate[Validate]
-  Validate --> Decompose[Decompose]
-  Decompose --> Materialize[Materialize issue]
+  Validate -->|ready| Materialize[Materialize implementation issue or issues]
   Materialize --> ImplementationIssue
 
   ImplementationIssue --> Approval{Implement enabled?}
@@ -71,7 +70,8 @@ flowchart TD
   or result comment.
 - Guests can submit issues, discussions, and feedback, but cannot approve work or start write automation.
 - GitVibe never auto-merges and never approves its own pull requests.
-- External agents are optional mention partners. GitVibe may post commands like `@codex review` or `@claude ...` only after admin/collaborator opt-in.
+- External agent mentions are not an implemented dispatch path. The shipped
+  config keeps `commands.allow_external_agent_mentions` disabled.
 
 ## Public Interfaces
 
@@ -81,14 +81,20 @@ Consumer config lives at:
 .github/git-vibe.yml
 ```
 
-Initial commands:
+Active dispatching commands:
 
 ```text
 /git-vibe investigate
 /git-vibe address-feedback
+/git-vibe materialize
 ```
 
 GitVibe uses `/git-vibe ...` as the only public command form. `@git-vibe ...` is intentionally unsupported so commands do not look like GitHub account mentions. GitHub does not currently provide a stable custom repository command autocomplete contract, so command parsing must work from plain comment text.
+
+Only implemented command dispatch paths start workflows: `/git-vibe investigate`
+on issue comments, `/git-vibe address-feedback` on pull request conversation
+comments, and `/git-vibe materialize` on Discussion comments after validation.
+Validation, approval, and standalone PR review are label-triggered paths.
 
 Active label flow:
 

--- a/packages/git-vibe-setup/.prettierignore
+++ b/packages/git-vibe-setup/.prettierignore
@@ -1,0 +1,2 @@
+dist/**
+coverage/**

--- a/packages/git-vibe-setup/package.json
+++ b/packages/git-vibe-setup/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "type": "module",
   "bin": {
-    "git-vibe-setup": "./dist/cli.js"
+    "git-vibe-setup": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json && node -e \"require('node:fs').chmodSync('dist/cli.js', 0o755)\"",
     "check": "prettier --check . && eslint . && corepack pnpm typecheck && corepack pnpm test && corepack pnpm build",
     "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json --noEmit"

--- a/packages/git-vibe-setup/tests/setup-cli.test.mjs
+++ b/packages/git-vibe-setup/tests/setup-cli.test.mjs
@@ -30,7 +30,7 @@ describe("git-vibe-setup", () => {
     const packageJson = JSON.parse(readFileSync(join(repositoryRoot, "package.json"), "utf8"));
 
     expect(packageJson.name).toBe("git-vibe-setup");
-    expect(packageJson.bin["git-vibe-setup"]).toBe("./dist/cli.js");
+    expect(packageJson.bin["git-vibe-setup"]).toBe("dist/cli.js");
     expect(packageJson.files).toEqual(expect.arrayContaining(["templates"]));
   });
 });

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -445,7 +445,7 @@ describe("GitVibe automatic PR review workflow", () => {
     expect(consumer.on?.pull_request_target).toBeUndefined();
     expect(wrapper.on?.pull_request_target).toMatchObject({
       branches: ["dev"],
-      types: ["opened", "reopened", "ready_for_review"],
+      types: ["opened", "reopened", "synchronize", "ready_for_review"],
     });
     expect(wrapper.jobs?.review).toMatchObject({
       if: "${{ !github.event.pull_request.draft }}",
@@ -476,7 +476,7 @@ describe("GitVibe automatic PR review workflow", () => {
       "cancel-in-progress": true,
     });
     expect(wrapper.concurrency).toMatchObject({
-      group: "git-vibe-review-${{ github.event.pull_request.number }}",
+      group: "git-vibe-review-dev-pr-${{ github.event.pull_request.number }}",
       "cancel-in-progress": true,
     });
   });

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -57,7 +57,11 @@ const workflowRunNameSpecs = [
   { file: ".github/workflows/investigate.yml", stage: "investigate", artifact: "Issue" },
   { file: ".github/workflows/develop.yml", stage: "develop", artifact: "Issue" },
   { file: ".github/workflows/review.yml", stage: "review", artifact: "PR" },
-  { file: ".github/workflows/review-dev-pr.yml", stage: "review-dev", artifact: "PR" },
+  {
+    file: ".github/workflows/automatic-pr-review.yml",
+    stage: "automatic-pr-review",
+    artifact: "PR",
+  },
   { file: ".github/workflows/address-feedback.yml", stage: "address-feedback", artifact: "PR" },
   {
     file: "examples/consumer/.github/workflows/validate.yml",
@@ -90,7 +94,7 @@ const workflowStaticNames = {
   ".github/workflows/investigate.yml": "GitVibe investigate",
   ".github/workflows/develop.yml": "GitVibe develop",
   ".github/workflows/review.yml": "GitVibe review",
-  ".github/workflows/review-dev-pr.yml": "GitVibe review dev PR",
+  ".github/workflows/automatic-pr-review.yml": "GitVibe automatic PR review",
   ".github/workflows/address-feedback.yml": "GitVibe address feedback",
   "examples/consumer/.github/workflows/validate.yml": "GitVibe validate",
   "examples/consumer/.github/workflows/materialize.yml": "GitVibe materialize",
@@ -437,14 +441,14 @@ describe("GitVibe workflow write permissions", () => {
 
 describe("GitVibe automatic PR review workflow", () => {
   it("keeps PR-open automation in a repo-local wrapper around review.yml", () => {
-    const wrapper = readWorkflow(".github/workflows/review-dev-pr.yml");
+    const wrapper = readWorkflow(".github/workflows/automatic-pr-review.yml");
     const source = readWorkflow(".github/workflows/review.yml");
     const consumer = readWorkflow("examples/consumer/.github/workflows/review.yml");
 
     expect(source.on?.pull_request_target).toBeUndefined();
     expect(consumer.on?.pull_request_target).toBeUndefined();
     expect(wrapper.on?.pull_request_target).toMatchObject({
-      branches: ["dev"],
+      branches: ["main", "dev"],
       types: ["opened", "reopened", "synchronize", "ready_for_review"],
     });
     expect(wrapper.jobs?.review).toMatchObject({
@@ -469,14 +473,14 @@ describe("GitVibe automatic PR review workflow", () => {
 
   it("cancels older in-progress review runs for the same pull request", () => {
     const source = readWorkflow(".github/workflows/review.yml");
-    const wrapper = readWorkflow(".github/workflows/review-dev-pr.yml");
+    const wrapper = readWorkflow(".github/workflows/automatic-pr-review.yml");
 
     expect(source.concurrency).toMatchObject({
       group: "git-vibe-review-${{ inputs.pr-number }}",
       "cancel-in-progress": true,
     });
     expect(wrapper.concurrency).toMatchObject({
-      group: "git-vibe-review-dev-pr-${{ github.event.pull_request.number }}",
+      group: "git-vibe-automatic-pr-review-${{ github.event.pull_request.number }}",
       "cancel-in-progress": true,
     });
   });


### PR DESCRIPTION
## Summary
- fix git-vibe-setup npm metadata so local publish dry-runs keep the CLI bin
- make the setup CLI build executable and ignore generated package output during package-local formatting
- align docs with the current stage/workflow model and note that external agent mentions are not active dispatch paths

## Verification
- corepack pnpm --filter git-vibe-setup check
- npm publish --dry-run --json from packages/git-vibe-setup
- corepack pnpm check

Note: npm package publishing remains a local release step; this PR does not add npm publishing to the GitHub release pipeline.