### PR TITLE
Fix reusable workflow action source checkout

### DIFF
--- a/.github/workflows/address-feedback.yml
+++ b/.github/workflows/address-feedback.yml
@@ -33,16 +33,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository. Empty means this repository.
-        required: false
-        type: string
-        default: ""
-      action-ref:
-        description: GitVibe action source ref. Empty means this workflow ref.
-        required: false
-        type: string
-        default: ""
   workflow_call:
     inputs:
       pr-number:
@@ -74,16 +64,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository.
-        required: false
-        type: string
-        default: markhuangai/git-vibe
-      action-ref:
-        description: GitVibe action source ref.
-        required: false
-        type: string
-        default: v3
     secrets:
       GITVIBE_GITHUB_TOKEN:
         description: Fine-grained PAT used for GitHub API access.
@@ -113,8 +93,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -150,8 +130,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -207,8 +187,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -264,8 +244,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/address-feedback.yml
+++ b/.github/workflows/address-feedback.yml
@@ -93,8 +93,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -130,8 +130,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -187,8 +187,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -244,8 +244,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/automatic-pr-review.yml
+++ b/.github/workflows/automatic-pr-review.yml
@@ -28,8 +28,6 @@ jobs:
       max_turns: 90
       dry-run: false
       source-comment: ""
-      action-repository: ${{ github.repository }}
-      action-ref: ${{ github.event.pull_request.base.ref }}
     secrets:
       GITVIBE_GITHUB_TOKEN: ${{ secrets.GITVIBE_GITHUB_TOKEN }}
       GITVIBE_AI_ENV_JSON: ${{ secrets.GITVIBE_AI_ENV_JSON }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -142,8 +142,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -176,8 +176,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -213,8 +213,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -252,8 +252,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -292,8 +292,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -352,8 +352,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -58,16 +58,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository. Empty means this repository.
-        required: false
-        type: string
-        default: ""
-      action-ref:
-        description: GitVibe action source ref. Empty means this workflow ref.
-        required: false
-        type: string
-        default: ""
   workflow_call:
     inputs:
       issue-number:
@@ -124,16 +114,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository.
-        required: false
-        type: string
-        default: markhuangai/git-vibe
-      action-ref:
-        description: GitVibe action source ref.
-        required: false
-        type: string
-        default: v3
     secrets:
       GITVIBE_GITHUB_TOKEN:
         description: Fine-grained PAT used for GitHub API access.
@@ -162,8 +142,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -196,8 +176,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -233,8 +213,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -272,8 +252,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -312,8 +292,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -372,8 +352,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -93,8 +93,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -130,8 +130,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -182,8 +182,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -33,16 +33,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository. Empty means this repository.
-        required: false
-        type: string
-        default: ""
-      action-ref:
-        description: GitVibe action source ref. Empty means this workflow ref.
-        required: false
-        type: string
-        default: ""
   workflow_call:
     inputs:
       issue-number:
@@ -74,16 +64,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository.
-        required: false
-        type: string
-        default: markhuangai/git-vibe
-      action-ref:
-        description: GitVibe action source ref.
-        required: false
-        type: string
-        default: v3
     secrets:
       GITVIBE_GITHUB_TOKEN:
         description: Fine-grained PAT used for GitHub API access.
@@ -113,8 +93,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -150,8 +130,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -202,8 +182,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/materialize.yml
+++ b/.github/workflows/materialize.yml
@@ -33,16 +33,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository. Empty means this repository.
-        required: false
-        type: string
-        default: ""
-      action-ref:
-        description: GitVibe action source ref. Empty means this workflow ref.
-        required: false
-        type: string
-        default: ""
   workflow_call:
     inputs:
       discussion-number:
@@ -74,16 +64,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository.
-        required: false
-        type: string
-        default: markhuangai/git-vibe
-      action-ref:
-        description: GitVibe action source ref.
-        required: false
-        type: string
-        default: v3
     secrets:
       GITVIBE_GITHUB_TOKEN:
         description: Fine-grained PAT used for GitHub API access.
@@ -110,8 +90,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/materialize.yml
+++ b/.github/workflows/materialize.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -33,16 +33,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository. Empty means this repository.
-        required: false
-        type: string
-        default: ""
-      action-ref:
-        description: GitVibe action source ref. Empty means this workflow ref.
-        required: false
-        type: string
-        default: ""
   workflow_call:
     inputs:
       pr-number:
@@ -74,16 +64,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository.
-        required: false
-        type: string
-        default: markhuangai/git-vibe
-      action-ref:
-        description: GitVibe action source ref.
-        required: false
-        type: string
-        default: v3
     secrets:
       GITVIBE_GITHUB_TOKEN:
         description: Fine-grained PAT used for GitHub API access.
@@ -117,8 +97,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -154,8 +134,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -212,8 +192,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -97,8 +97,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -134,8 +134,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -192,8 +192,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,16 +39,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository. Empty means this repository.
-        required: false
-        type: string
-        default: ""
-      action-ref:
-        description: GitVibe action source ref. Empty means this workflow ref.
-        required: false
-        type: string
-        default: ""
   workflow_call:
     inputs:
       issue-number:
@@ -86,16 +76,6 @@ on:
         required: false
         type: string
         default: ""
-      action-repository:
-        description: GitVibe action source repository.
-        required: false
-        type: string
-        default: markhuangai/git-vibe
-      action-ref:
-        description: GitVibe action source ref.
-        required: false
-        type: string
-        default: v3
     secrets:
       GITVIBE_GITHUB_TOKEN:
         description: Fine-grained PAT used for GitHub API access.
@@ -125,8 +105,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -162,8 +142,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -215,8 +195,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.action-repository || github.repository }}
-          ref: ${{ inputs.action-ref || github.ref_name }}
+          repository: markhuangai/git-vibe
+          ref: ${{ github.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -142,8 +142,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:
@@ -195,8 +195,8 @@ jobs:
       - name: Checkout GitVibe action source
         uses: actions/checkout@v4
         with:
-          repository: markhuangai/git-vibe
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .git-vibe/actions
       - uses: pnpm/action-setup@v4
         with:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -18,7 +18,7 @@
 - `.github/workflows/ci.yml`: PR quality gate plus manual dispatch for format, lint, coverage, build, actionlint, and production audit.
 - `.github/workflows/app-deploy.yml`: app image build and deployment workflow for app/shared runtime changes on `dev`.
 - `.github/workflows/release.yml`: admin-only manual release workflow that runs from `main`, creates GitHub releases, and promotes the existing GHCR app image to the release tag.
-- Reusable GitVibe workflows also support `workflow_dispatch` for source-repo testing. Direct dispatch defaults the action source to the current repository/ref, while `workflow_call` defaults to the pinned `markhuangai/git-vibe@v3` release.
+- Reusable GitVibe workflows also support `workflow_dispatch` for source-repo testing. GitVibe action source checkouts use the `markhuangai/git-vibe` repository at the commit of the reusable workflow file itself, so called workflows run action code from the same GitVibe ref used in `uses:`.
 - `.github/workflows/ai-smoke.yml`: manual repo-local smoke test for self-hosted AI runner setup.
 - `investigate/`, `validate/`, `materialize/`, `implement/`, `create-pr/`,
   `review-matrix/`, `address-pr-feedback/`, `plan-stage/`, and

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "LICENSE"
   ],
   "scripts": {
-    "actionlint": "github-actionlint .github/workflows/*.yml examples/consumer/.github/workflows/*.yml",
+    "actionlint": "github-actionlint -ignore 'property \"workflow_(repository|sha)\" is not defined' .github/workflows/*.yml examples/consumer/.github/workflows/*.yml",
     "build": "tsc --project tsconfig.build.json && node scripts/build-actions.mjs && corepack pnpm --filter git-vibe-setup build",
     "build:app": "tsc --project tsconfig.build.json",
     "bundle:actions": "node scripts/build-actions.mjs",
-    "check": "prettier --check . && eslint . && (command -v pnpm >/dev/null 2>&1 || command -v corepack >/dev/null 2>&1 || (echo 'pnpm or Corepack is required.' && exit 127)) && PNPM=\"$(command -v pnpm >/dev/null 2>&1 && echo pnpm || echo 'corepack pnpm')\" && $PNPM workflow-template-contract && $PNPM typecheck && vitest run --coverage && $PNPM build && github-actionlint .github/workflows/*.yml examples/consumer/.github/workflows/*.yml && $PNPM audit --prod",
+    "check": "prettier --check . && eslint . && (command -v pnpm >/dev/null 2>&1 || command -v corepack >/dev/null 2>&1 || (echo 'pnpm or Corepack is required.' && exit 127)) && PNPM=\"$(command -v pnpm >/dev/null 2>&1 && echo pnpm || echo 'corepack pnpm')\" && $PNPM workflow-template-contract && $PNPM typecheck && vitest run --coverage && $PNPM build && $PNPM actionlint && $PNPM audit --prod",
     "coverage": "vitest run --coverage",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/check-workflow-template-contract.mjs
+++ b/scripts/check-workflow-template-contract.mjs
@@ -11,8 +11,8 @@ import { parse } from "yaml";
 const sourceWorkflowDirectory = ".github/workflows";
 const consumerWorkflowDirectory = "examples/consumer/.github/workflows";
 const localReusableWorkflowTemplates = [".github/workflows/automatic-pr-review.yml"];
-const internalWorkflowCallInputs = new Set(["action-repository", "action-ref"]);
-const remoteReusableWorkflowPattern = /^markhuangai\/git-vibe\/\.github\/workflows\/([^@\s]+)@.+$/;
+const remoteReusableWorkflowPattern =
+  /^markhuangai\/git-vibe\/\.github\/workflows\/([^@\s]+)@([^\s]+)$/;
 const localReusableWorkflowPattern = /^\.\/\.github\/workflows\/([^@\s]+)$/;
 const dispatchInputExpressionPattern = /^\${{\s*github\.event\.inputs\.([A-Za-z0-9_-]+)\s*}}$/;
 const dispatchInputJsonExpressionPattern =
@@ -95,7 +95,6 @@ function checkReusableInputs(templatePath, sourcePath, template, reusableJob, so
  */
 function checkForwardedInputs(templatePath, sourcePath, withInputs, sourceInputs) {
   for (const name of Object.keys(sourceInputs)) {
-    if (internalWorkflowCallInputs.has(name)) continue;
     if (!Object.hasOwn(withInputs, name)) {
       errors.push(`${templatePath} must pass ${name} to ${sourcePath}.`);
     }

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -8,7 +8,7 @@ import { workflowBudgetInputsFor } from "../src/shared/budgets.ts";
  * @typedef {{ concurrency?: { group?: string, ["cancel-in-progress"]?: boolean }, env?: Record<string, string>, inputs?: Record<string, WorkflowInput>, jobs?: Record<string, WorkflowJob>, name?: string, on?: { pull_request_target?: { branches?: string[], types?: string[] }, push?: { paths?: string[] }, workflow_call?: { inputs?: Record<string, WorkflowInput>, secrets?: Record<string, { required?: boolean }> }, workflow_dispatch?: { inputs?: Record<string, WorkflowInput> } }, outputs?: Record<string, { description?: string, value?: string }>, permissions?: Record<string, string>, ["run-name"]?: string }} Workflow
  * @typedef {{ env?: Record<string, string>, if?: string, name?: string, needs?: string, outputs?: Record<string, string>, permissions?: Record<string, string>, secrets?: Record<string, string>, steps?: WorkflowStep[], ["timeout-minutes"]?: string, uses?: string, with?: Record<string, unknown> }} WorkflowJob
  * @typedef {{ env?: Record<string, string>, id?: string, if?: string, name?: string, run?: string, uses?: string, with?: Record<string, unknown> }} WorkflowStep
- * @typedef {{ env: Record<string, string>, name?: string, uses?: string }} SimulatedStep
+ * @typedef {{ env: Record<string, string>, name?: string, uses?: string, with?: Record<string, unknown> }} SimulatedStep
  */
 
 const aiEnv = {
@@ -209,19 +209,22 @@ describe("GitVibe workflow call wiring", () => {
       const workflow = readWorkflow(file);
       const workflowCall = workflow.on?.workflow_call;
       const checkoutSteps = gitVibeActionSteps(workflow, (uses) => uses === "actions/checkout@v4");
+      const actionSourceSteps = checkoutSteps.filter(
+        ({ name }) => name === "Checkout GitVibe action source",
+      );
 
       expect(workflow.on?.workflow_dispatch, `${file} declares workflow_dispatch`).toBeTruthy();
-      expect(
-        workflowCall?.secrets?.GITVIBE_AI_ENV_JSON,
-        `${file} declares AI env bundle`,
-      ).toMatchObject({
-        required: true,
-      });
+      expect(workflow.on?.workflow_dispatch?.inputs?.["action-repository"]).toBeUndefined();
+      expect(workflow.on?.workflow_dispatch?.inputs?.["action-ref"]).toBeUndefined();
+      expect(workflowCall?.inputs?.["action-repository"]).toBeUndefined();
+      expect(workflowCall?.inputs?.["action-ref"]).toBeUndefined();
+      expect(workflowCall?.secrets?.GITVIBE_AI_ENV_JSON).toMatchObject({ required: true });
       expect(workflowCall?.secrets?.GITVIBE_AI_API_KEY, `${file} omits old AI key`).toBeUndefined();
-      expect(
-        checkoutSteps.some((step) => step.name === "Checkout GitVibe action source"),
-        `${file} checks out action source`,
-      ).toBe(true);
+      expect(actionSourceSteps.length).toBeGreaterThan(0);
+      for (const step of actionSourceSteps) {
+        expect(step.with?.repository).toBe("markhuangai/git-vibe");
+        expect(step.with?.ref).toBe("${{ github.workflow_sha }}");
+      }
     }
   });
 
@@ -241,10 +244,9 @@ describe("GitVibe workflow call wiring", () => {
       });
       expect(reusableJob?.secrets?.GITVIBE_AI_API_KEY, `${file} omits old AI key`).toBeUndefined();
       expect(reusableJob?.secrets?.CODEX_AUTH_JSON, `${file} omits old Codex auth`).toBeUndefined();
-      expect(
-        reusableJob?.secrets?.CLAUDE_CODE_OAUTH_TOKEN,
-        `${file} omits old Claude auth`,
-      ).toBeUndefined();
+      expect(reusableJob?.secrets?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      expect(reusableJob?.with?.["action-repository"]).toBeUndefined();
+      expect(reusableJob?.with?.["action-ref"]).toBeUndefined();
     }
   });
 
@@ -494,8 +496,6 @@ describe("GitVibe automatic PR review workflow", () => {
       },
       uses: "./.github/workflows/review.yml",
       with: {
-        "action-ref": "${{ github.event.pull_request.base.ref }}",
-        "action-repository": "${{ github.repository }}",
         "dry-run": false,
         max_turns: 90,
         "pr-number": "${{ format('{0}', github.event.pull_request.number) }}",
@@ -684,6 +684,7 @@ function gitVibeActionSteps(workflow, matchesUse) {
         env: { ...(workflow.env || {}), ...(job.env || {}), ...(step.env || {}) },
         name: step.name,
         uses: step.uses,
+        with: step.with,
       })),
   );
 }

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -222,8 +222,8 @@ describe("GitVibe workflow call wiring", () => {
       expect(workflowCall?.secrets?.GITVIBE_AI_API_KEY, `${file} omits old AI key`).toBeUndefined();
       expect(actionSourceSteps.length).toBeGreaterThan(0);
       for (const step of actionSourceSteps) {
-        expect(step.with?.repository).toBe("markhuangai/git-vibe");
-        expect(step.with?.ref).toBe("${{ github.workflow_sha }}");
+        expect(step.with?.repository).toBe("${{ job.workflow_repository }}");
+        expect(step.with?.ref).toBe("${{ job.workflow_sha }}");
       }
     }
   });


### PR DESCRIPTION
## Summary
- remove action source override inputs from reusable GitVibe workflows
- checkout GitVibe action runtime from markhuangai/git-vibe at github.workflow_sha
- update automatic PR review wrapper, workflow contract tests, and development docs

## Checks
- corepack pnpm check
- workflow-template-contract
- github-actionlint
- VCP pre-commit review: PASS fallback manual review because VCP MCP tools were unavailable in this turn