### PR TITLE
Merge dev into main

### DIFF
--- a/src/runner/actions/setup-ai-cli.ts
+++ b/src/runner/actions/setup-ai-cli.ts
@@ -139,17 +139,36 @@ function installCodex(
   }
 
   const installDir = join(runnerTemp(env), "git-vibe-pnpm-global");
-  mkdirSync(installDir, { recursive: true });
-  const installEnv = prependPath({ ...env, PNPM_HOME: installDir }, installDir);
+  const binDir = join(installDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  // Some self-hosted runners carry pnpm global-bin-dir config in the environment.
+  // Keep pnpm's configured bin dir, PATH, and GITHUB_PATH on the same explicit path,
+  // otherwise `pnpm add --global` fails before installing the CLI.
+  const installEnv = prependPaths(
+    {
+      ...env,
+      NPM_CONFIG_GLOBAL_BIN_DIR: binDir,
+      PNPM_HOME: installDir,
+      npm_config_global_bin_dir: binDir,
+    },
+    [binDir, installDir],
+  );
   const packageManager = pnpmCommand(runtime, installEnv);
 
   log("Installing Codex CLI from @openai/codex.");
   runCommand(
     runtime,
     packageManager.command,
-    [...packageManager.args, "add", "--global", "@openai/codex"],
+    [
+      ...packageManager.args,
+      `--config.global-bin-dir=${binDir}`,
+      "add",
+      "--global",
+      "@openai/codex",
+    ],
     installEnv,
   );
+  addPath(runtime, binDir, env);
   addPath(runtime, installDir, env);
   verifyCommand(runtime, "codex", installEnv);
 }
@@ -249,6 +268,10 @@ function addPath(runtime: SetupAiCliRuntime, path: string, env: NodeJS.ProcessEn
 
 function prependPath(env: NodeJS.ProcessEnv, path: string): NodeJS.ProcessEnv {
   return { ...env, PATH: [path, env.PATH].filter(Boolean).join(delimiter) };
+}
+
+function prependPaths(env: NodeJS.ProcessEnv, paths: string[]): NodeJS.ProcessEnv {
+  return { ...env, PATH: [...paths, env.PATH].filter(Boolean).join(delimiter) };
 }
 
 function firstLine(output: Buffer | string): string | undefined {

--- a/tests/setup-ai-cli.test.mjs
+++ b/tests/setup-ai-cli.test.mjs
@@ -101,7 +101,9 @@ describe("GitVibe AI CLI setup Codex installer", () => {
     expectNoCommand(calls, "corepack");
     expectNoCommand(calls, "pnpm");
   });
+});
 
+describe("GitVibe AI CLI setup Codex pnpm installer", () => {
   it("installs Codex CLI with pnpm when a selected stage uses cli-codex", () => {
     const cwd = configuredWorkspace(codexConfig());
     const env = runtimeEnv(cwd);
@@ -116,36 +118,88 @@ describe("GitVibe AI CLI setup Codex installer", () => {
     });
 
     expect(code).toBe(0);
-    const globalBinDir = join(env.RUNNER_TEMP, "git-vibe-cli", "git-vibe-pnpm-global");
+    const installDir = join(env.RUNNER_TEMP, "git-vibe-cli", "git-vibe-pnpm-global");
+    const globalBinDir = join(installDir, "bin");
     const installCall = calls.find(
       (call) =>
         call.command === "corepack" &&
-        JSON.stringify(call.args) === JSON.stringify(["pnpm", "add", "--global", "@openai/codex"]),
+        JSON.stringify(call.args) ===
+          JSON.stringify([
+            "pnpm",
+            `--config.global-bin-dir=${globalBinDir}`,
+            "add",
+            "--global",
+            "@openai/codex",
+          ]),
     );
 
-    expectCommand(calls, "corepack", ["pnpm", "add", "--global", "@openai/codex"]);
-    expect(installCall?.env?.PNPM_HOME).toBe(
-      join(env.RUNNER_TEMP, "git-vibe-cli", "git-vibe-pnpm-global"),
-    );
+    expectCommand(calls, "corepack", [
+      "pnpm",
+      `--config.global-bin-dir=${globalBinDir}`,
+      "add",
+      "--global",
+      "@openai/codex",
+    ]);
+    expect(installCall?.env?.PNPM_HOME).toBe(installDir);
+    expect(installCall?.env?.NPM_CONFIG_GLOBAL_BIN_DIR).toBe(globalBinDir);
+    expect(installCall?.env?.npm_config_global_bin_dir).toBe(globalBinDir);
     expect(installCall?.env?.PATH?.split(delimiter)[0]).toBe(globalBinDir);
+    expect(installCall?.env?.PATH?.split(delimiter)[1]).toBe(installDir);
     expectCommand(calls, "codex", ["--version"]);
     expect(readFileSync(env.GITHUB_PATH, "utf8")).toContain(globalBinDir);
+    expect(readFileSync(env.GITHUB_PATH, "utf8")).toContain(installDir);
   });
 
-  it("uses installed pnpm when Corepack is unavailable", () => {
+  it("overrides preconfigured pnpm global bin directories", () => {
     const cwd = configuredWorkspace(codexConfig());
+    const env = {
+      ...runtimeEnv(cwd),
+      NPM_CONFIG_GLOBAL_BIN_DIR: "/runner/pnpm/bin",
+      npm_config_global_bin_dir: "/runner/pnpm/bin",
+    };
     /** @type {CommandCall[]} */
     const calls = [];
 
     const code = setupAiCli({
       argv: ["validate"],
-      env: runtimeEnv(cwd),
+      env,
+      execFileSync: execMock(calls, ["codex"]),
+      log: () => undefined,
+    });
+
+    expect(code).toBe(0);
+    const globalBinDir = join(env.RUNNER_TEMP, "git-vibe-cli", "git-vibe-pnpm-global", "bin");
+    const installCall = calls.find((call) => call.command === "corepack");
+
+    expect(installCall?.args).toContain(`--config.global-bin-dir=${globalBinDir}`);
+    expect(installCall?.env?.NPM_CONFIG_GLOBAL_BIN_DIR).toBe(globalBinDir);
+    expect(installCall?.env?.npm_config_global_bin_dir).toBe(globalBinDir);
+    expect(installCall?.env?.PATH?.split(delimiter)[0]).toBe(globalBinDir);
+  });
+});
+
+describe("GitVibe AI CLI setup Codex pnpm provider selection", () => {
+  it("uses installed pnpm when Corepack is unavailable", () => {
+    const cwd = configuredWorkspace(codexConfig());
+    const env = runtimeEnv(cwd);
+    /** @type {CommandCall[]} */
+    const calls = [];
+
+    const code = setupAiCli({
+      argv: ["validate"],
+      env,
       execFileSync: execMock(calls, ["codex", "corepack"]),
       log: () => undefined,
     });
 
     expect(code).toBe(0);
-    expectCommand(calls, "pnpm", ["add", "--global", "@openai/codex"]);
+    const globalBinDir = join(env.RUNNER_TEMP, "git-vibe-cli", "git-vibe-pnpm-global", "bin");
+    expectCommand(calls, "pnpm", [
+      `--config.global-bin-dir=${globalBinDir}`,
+      "add",
+      "--global",
+      "@openai/codex",
+    ]);
   });
 
   it("reports an install error when no pnpm provider is available", () => {


### PR DESCRIPTION
## Summary
- merge current dev fixes into main
- fix Codex CLI pnpm global-bin-dir setup for self-hosted runners
- include managed runtime label trust handling and prompt-guided web policy updates

## Tests
- corepack pnpm check
- corepack pnpm vitest run tests/setup-ai-cli.test.mjs
- temp smoke install of @openai/codex with conflicting pnpm global-bin-dir config