### PR TITLE
Fix adapter validation prompts and PR review reruns

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ falling back to a profile name the repository may not have configured.
 Role definitions referenced by `role_group` live in `.git-vibe/role-group/*.md`.
 CLI adapters use fixed commands (`codex exec` and `claude -p`); profiles choose
 adapter, model, auth, env, and reasoning settings, not the executable command.
+They use native structured-output schema flags and do not receive
+`output_validator` tool-call instructions.
 Profiles may opt into shared repository guidance with
 `ai.profiles.<name>.context.files`. Listed files are appended to the rendered
 system prompt for that profile across `ai-sdk-agentool`, `cli-codex`, and

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -424,14 +424,14 @@ Adapter mappings:
 
 - `cli-codex`: run `codex exec` with `--dangerously-bypass-approvals-and-sandbox`; do not pass `--search`; map `reasoning.effort` to Codex `model_reasoning_effort`; map `reasoning.summary` to `model_reasoning_summary`.
 - `cli-claude-code`: run `claude -p` with `--dangerously-skip-permissions`; pass strict JSON Schema with `--json-schema`; map `reasoning.effort` to `--effort`. GitVibe does not set `--bare` unless a profile explicitly opts in with `bare: true`.
-- CLI adapters do not receive GitVibe stage tool lists or `max_turns`; Codex and Claude Code own their native agent/tool loop and run without per-tool permission prompts in this workflow.
+- CLI adapters do not receive GitVibe stage tool lists, `output_validator` tool-call instructions, or `max_turns`; Codex and Claude Code own their native agent/tool loop and run without per-tool permission prompts in this workflow.
 - `ai-sdk-agentool` with native OpenAI: map `reasoning.effort` to `providerOptions.openai.reasoningEffort`; map summaries to `providerOptions.openai.reasoningSummary` where applicable; set a stable `providerOptions.openai.promptCacheKey` by default.
 - `ai-sdk-agentool` with OpenAI-compatible endpoints: do not add OpenAI prompt cache request fields by default because non-OpenAI endpoints may reject unknown fields.
 - `ai-sdk-agentool` with Anthropic: map `reasoning.effort` to `providerOptions.anthropic.effort`; keep lower-level `thinking` config under `provider_options.anthropic` for explicit advanced use; set `providerOptions.anthropic.cacheControl: { type: "ephemeral" }` by default.
 
 AI SDK tool policy by stage:
 
-Stage `tools` config is optional and only applies to the `ai-sdk-agentool` adapter. When omitted, GitVibe uses the built-in defaults below. CLI adapters do not receive these tool lists because their native agents own tool selection.
+Stage `tools` config is optional and only applies to the `ai-sdk-agentool` adapter. When omitted, GitVibe uses the built-in defaults below. CLI adapters do not receive these tool lists because their native agents own tool selection. `output_validator` is an AI SDK tool only; CLI adapters use native structured-output schema flags and GitVibe post-validation.
 
 - `investigate`: read, grep, glob, diff, GitHub search, web fetch/search,
   and read-only `agent` subagents.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -78,7 +78,7 @@ In GitVibe stages, `cli-codex` runs `codex exec` with
 `--dangerously-bypass-approvals-and-sandbox`, `--output-schema`, and
 `--output-last-message`, and without `--search`; stdout and stderr stream to the
 action log while the final message file supplies the structured result for
-validation.
+validation. Codex CLI prompts do not include `output_validator` instructions.
 
 Claude Code smoke testing is optional. The workflow installs Claude Code through
 Anthropic's native installer when the `claude` command is missing, prompts
@@ -94,7 +94,7 @@ set `--bare` unless a profile explicitly opts in with `bare: true`. Configure
 Claude OAuth and provider env through profile `env.<NAME>` mappings using either
 `{ from_bundle: KEY }` or literal strings. CLI adapter progress is rendered to
 the action log while GitVibe still captures the structured result for
-validation.
+validation; Claude Code prompts do not include `output_validator` instructions.
 
 ## Quality Gates
 

--- a/prompts/_shared/system.md
+++ b/prompts/_shared/system.md
@@ -11,7 +11,7 @@ You are an AI agent running inside GitVibe, a repository webhook server and reus
 5. Prefer existing project patterns over new abstractions. Read the relevant files before proposing or making code changes.
 6. Validate findings before reporting them. A finding should name the concrete failure, the evidence that proves it, and the affected path or GitHub URL when available.
 7. Use `status: "completed"` only when the stage outcome is ready for GitVibe to act on. Use `status: "blocked"` for contradictions, unsafe state, missing authority, or required human input.
-8. Call `output_validator` with the exact final JSON object before responding. After validation, return only that JSON object. Do not wrap it in Markdown, prose, or code fences.
+8. Return only the final JSON object matching the stage schema. Do not wrap it in Markdown, prose, or code fences.
 9. Use `github_search` for project GitHub material when it is available. Do not load website content or use shell commands for network browsing when web tools are absent or disabled.
 
 ## GitHub Reply Behavior

--- a/prompts/_shared/user.md
+++ b/prompts/_shared/user.md
@@ -21,8 +21,7 @@
 5. Separate facts, assumptions, questions, and risks. Do not merge them into vague prose.
 6. Decide whether the stage is `completed` or `blocked`. If blocked, explain the blocking condition and do not trigger downstream work through a completed status.
 7. Build the final JSON object with every required field from the schema. Include optional fields only when they are useful and schema-valid.
-8. Call `output_validator` with the exact final JSON object.
-9. Return only the validated JSON object.
+8. Return only the final JSON object.
    </required_process>
 
 <status_rules>

--- a/src/runner/ai.ts
+++ b/src/runner/ai.ts
@@ -155,7 +155,11 @@ async function runAiStageWithProfile(
     throw new Error(`AI profile ${profileName} uses unsupported adapter ${adapter}.`);
   }
 
-  return runAiSdkStageWithProfile(profileOptions, profileName, profile);
+  return runAiSdkStageWithProfile(
+    aiSdkOutputValidationOptions(profileOptions),
+    profileName,
+    profile,
+  );
 }
 
 async function runAiSdkStageWithProfile(
@@ -210,6 +214,23 @@ async function runAiSdkStageWithProfile(
   } finally {
     await mcpTools.close();
   }
+}
+
+function aiSdkOutputValidationOptions(options: RunAiStageOptions): RunAiStageOptions {
+  return {
+    ...options,
+    prompt: [options.prompt, aiSdkOutputValidationInstruction()].join("\n\n"),
+  };
+}
+
+function aiSdkOutputValidationInstruction(): string {
+  return [
+    "<adapter_output_validation>",
+    "Call output_validator with content set to the exact final JSON object string.",
+    "If validation fails, fix every reported error and call output_validator again.",
+    "After validation, return only the same JSON object.",
+    "</adapter_output_validation>",
+  ].join("\n");
 }
 
 function aiSdkRuntime(options: {

--- a/src/runner/context.ts
+++ b/src/runner/context.ts
@@ -429,13 +429,16 @@ function toPullRequestReviewTimelineItem(item: PullRequestReviewCommentNode): Ti
 }
 
 function toPullRequestReviewBodyTimelineItem(item: PullRequestReviewResponse): TimelineItem {
-  return toTimelineItem("pull-request-review", String(item.node_id || item.id || ""), {
-    ...item,
-    body: item.body || "",
-    created_at: item.submitted_at,
-    html_url: item.html_url,
-    user: item.user,
-  });
+  return {
+    ...toTimelineItem("pull-request-review", String(item.node_id || item.id || ""), {
+      ...item,
+      body: item.body || "",
+      created_at: item.submitted_at,
+      html_url: item.html_url,
+      user: item.user,
+    }),
+    databaseId: item.id,
+  };
 }
 
 function discussionNodeToTimelineItem(

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -1,4 +1,5 @@
 import { GitHubClient, splitRepository } from "../shared/github.js";
+import { workflowRunIdFromUrl } from "../shared/status-comments.js";
 import type { ContextPacket, JsonObject, RunnerOptions } from "../shared/types.js";
 import type { StageLogger } from "./logging.js";
 
@@ -22,17 +23,41 @@ export async function publishPullRequestReviewResult(options: {
   if (!shouldPublishPullRequestReview(options)) return false;
 
   const comments = inlineReviewComments(options.parsedOutput.inline_comments);
+  const body = pullRequestReviewBody({
+    comments,
+    output: options.parsedOutput,
+    stageResultBody: options.stageResultBody,
+    workflowRunUrl: options.runner.workflowRunUrl,
+  });
+  const existingReview = editableReviewForStageResult({ ...options, comments });
+  if (existingReview) {
+    options.logger.event("github.pr.review.update.start", {
+      pull_request: options.context.artifact.number,
+      review: existingReview.reviewId,
+      run: workflowRunIdFromUrl(options.runner.workflowRunUrl),
+    });
+    await updatePullRequestReview({
+      body,
+      client: options.client,
+      pullNumber: options.context.artifact.number,
+      repository: options.runner.repository,
+      reviewId: existingReview.reviewId,
+      token: options.runner.token,
+    });
+    options.logger.event("github.pr.review.update.done", {
+      pull_request: options.context.artifact.number,
+      review: existingReview.reviewId,
+      run: workflowRunIdFromUrl(options.runner.workflowRunUrl),
+    });
+    return true;
+  }
+
   options.logger.event("github.pr.review.start", {
     comments: comments.length,
     pull_request: options.context.artifact.number,
   });
   await createPullRequestReview({
-    body: pullRequestReviewBody({
-      comments,
-      output: options.parsedOutput,
-      stageResultBody: options.stageResultBody,
-      workflowRunUrl: options.runner.workflowRunUrl,
-    }),
+    body,
     client: options.client,
     comments,
     pullNumber: options.context.artifact.number,
@@ -56,6 +81,69 @@ function shouldPublishPullRequestReview(options: {
   );
 }
 
+function editableReviewForStageResult(options: {
+  comments: PullRequestReviewComment[];
+  context: ContextPacket;
+  runner: RunnerOptions;
+}): { reviewId: string } | undefined {
+  if (options.comments.length > 0) return undefined;
+  const run = workflowRunIdFromUrl(options.runner.workflowRunUrl);
+  if (!run) return undefined;
+  let editableReview: { reviewId: string } | undefined;
+  for (const item of options.context.timeline) {
+    if (item.kind !== "pull-request-review") continue;
+    const reviewId = reviewDatabaseId(item.databaseId);
+    if (!reviewId) continue;
+    const marker = parseStageResultMarker(item.body);
+    if (
+      marker?.artifact === options.context.artifact.type &&
+      marker.number === options.context.artifact.number &&
+      marker.stage === options.runner.stage &&
+      markerMatchesRun(marker, item.body, run) &&
+      reviewInlineCommentCount(item.body) === 0
+    ) {
+      editableReview = { reviewId };
+    }
+  }
+  return editableReview;
+}
+
+function parseStageResultMarker(
+  body: string,
+): { artifact: string; number: string; run?: string; stage: string } | undefined {
+  const match = body.match(/<!--\s*git-vibe:stage-result\s+([^>]*)-->/);
+  if (!match) return undefined;
+  const attributes = Object.fromEntries(
+    [...(match[1] || "").matchAll(/([a-z][a-z-]*)=([^\s>]+)/g)].map((entry) => [
+      entry[1],
+      entry[2],
+    ]),
+  );
+  if (!attributes.stage || !attributes.artifact || !attributes.number) return undefined;
+  return {
+    artifact: attributes.artifact,
+    number: attributes.number,
+    run: attributes.run,
+    stage: attributes.stage,
+  };
+}
+
+function markerMatchesRun(marker: { run?: string }, body: string, run: string): boolean {
+  if (marker.run) return marker.run === run;
+  return body.includes(`/actions/runs/${run}`);
+}
+
+function reviewInlineCommentCount(body: string): number {
+  const match = body.match(/\*\*Inline comments:\*\*\s+(\d+)/);
+  return match ? Number(match[1]) : 0;
+}
+
+function reviewDatabaseId(value: number | string | undefined): string | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) return String(value);
+  if (typeof value === "string" && /^\d+$/.test(value)) return value;
+  return undefined;
+}
+
 async function createPullRequestReview(options: {
   body: string;
   client: GitHubClient;
@@ -73,6 +161,23 @@ async function createPullRequestReview(options: {
     },
     method: "POST",
     path: `/repos/${owner}/${repo}/pulls/${options.pullNumber}/reviews`,
+    token: options.token,
+  });
+}
+
+async function updatePullRequestReview(options: {
+  body: string;
+  client: GitHubClient;
+  pullNumber: string;
+  repository: string;
+  reviewId: string;
+  token: string;
+}): Promise<void> {
+  const { owner, repo } = splitRepository(options.repository);
+  await options.client.request({
+    body: { body: options.body },
+    method: "PUT",
+    path: `/repos/${owner}/${repo}/pulls/${options.pullNumber}/reviews/${options.reviewId}`,
     token: options.token,
   });
 }

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -12,6 +12,10 @@ interface PullRequestReviewComment {
   start_side?: "LEFT" | "RIGHT";
 }
 
+interface AuthenticatedUserResponse extends JsonObject {
+  login?: string;
+}
+
 export async function publishPullRequestReviewResult(options: {
   client: GitHubClient;
   context: ContextPacket;
@@ -29,7 +33,7 @@ export async function publishPullRequestReviewResult(options: {
     stageResultBody: options.stageResultBody,
     workflowRunUrl: options.runner.workflowRunUrl,
   });
-  const existingReview = editableReviewForStageResult({ ...options, comments });
+  const existingReview = await editableReviewForStageResult({ ...options, comments });
   if (existingReview) {
     options.logger.event("github.pr.review.update.start", {
       pull_request: options.context.artifact.number,
@@ -81,15 +85,16 @@ function shouldPublishPullRequestReview(options: {
   );
 }
 
-function editableReviewForStageResult(options: {
+async function editableReviewForStageResult(options: {
+  client: GitHubClient;
   comments: PullRequestReviewComment[];
   context: ContextPacket;
   runner: RunnerOptions;
-}): { reviewId: string } | undefined {
+}): Promise<{ reviewId: string } | undefined> {
   if (options.comments.length > 0) return undefined;
   const run = workflowRunIdFromUrl(options.runner.workflowRunUrl);
   if (!run) return undefined;
-  let editableReview: { reviewId: string } | undefined;
+  const candidates: Array<{ author: string; reviewId: string }> = [];
   for (const item of options.context.timeline) {
     if (item.kind !== "pull-request-review") continue;
     const reviewId = reviewDatabaseId(item.databaseId);
@@ -102,7 +107,19 @@ function editableReviewForStageResult(options: {
       markerMatchesRun(marker, item.body, run) &&
       reviewInlineCommentCount(item.body) === 0
     ) {
-      editableReview = { reviewId };
+      candidates.push({ author: item.author, reviewId });
+    }
+  }
+  if (!candidates.length) return undefined;
+
+  const login = await authenticatedGitHubLogin({
+    client: options.client,
+    token: options.runner.token,
+  });
+  let editableReview: { reviewId: string } | undefined;
+  for (const candidate of candidates) {
+    if (sameGitHubLogin(candidate.author, login)) {
+      editableReview = { reviewId: candidate.reviewId };
     }
   }
   return editableReview;
@@ -142,6 +159,28 @@ function reviewDatabaseId(value: number | string | undefined): string | undefine
   if (typeof value === "number" && Number.isInteger(value) && value > 0) return String(value);
   if (typeof value === "string" && /^\d+$/.test(value)) return value;
   return undefined;
+}
+
+function sameGitHubLogin(left: string, right: string): boolean {
+  return left.trim().toLowerCase() === right.trim().toLowerCase();
+}
+
+async function authenticatedGitHubLogin(options: {
+  client: GitHubClient;
+  token: string;
+}): Promise<string> {
+  const user = await options.client.request<AuthenticatedUserResponse>({
+    method: "GET",
+    path: "/user",
+    token: options.token,
+  });
+  const login = stringField(user.login);
+  if (!login) {
+    throw new Error(
+      "GitHub authenticated user did not include login; cannot safely update PR review.",
+    );
+  }
+  return login;
 }
 
 async function createPullRequestReview(options: {

--- a/src/runner/result-comments.ts
+++ b/src/runner/result-comments.ts
@@ -73,7 +73,9 @@ export function renderStageResultComment(options: StageResultCommentOptions): st
 
 function resultMarker(options: StageResultCommentOptions): string {
   const artifact = options.context.artifact;
-  return `<!-- git-vibe:stage-result stage=${options.stage} artifact=${artifact.type} number=${artifact.number} -->`;
+  const run = workflowRunIdFromUrl(options.workflowRunUrl);
+  const runAttribute = run ? ` run=${run}` : "";
+  return `<!-- git-vibe:stage-result stage=${options.stage} artifact=${artifact.type} number=${artifact.number}${runAttribute} -->`;
 }
 
 function stageTitle(options: Pick<StageResultCommentOptions, "context" | "stage">): string {

--- a/src/runner/stage-dry-run.ts
+++ b/src/runner/stage-dry-run.ts
@@ -8,7 +8,7 @@ export function stageContract(stage: string, context: ContextPacket): string {
   const branchRule = deterministicBranch
     ? ` GitVibe has already prepared branch ${deterministicBranch}; stay on that branch, use it exactly, and do not fetch, checkout, reset, merge, push, or invent a branch name.`
     : "";
-  return `Stage ${stage} is running.${branchRule} Return only JSON matching the schema. Call output_validator with the exact final JSON before responding.`;
+  return `Stage ${stage} is running.${branchRule} Return only JSON matching the schema.`;
 }
 
 export function dryRunContent(stage: string, context: ContextPacket, logger: StageLogger): string {

--- a/tests/ai-compaction.test.mjs
+++ b/tests/ai-compaction.test.mjs
@@ -233,7 +233,8 @@ describe("AI context compaction stage wiring", () => {
     compactMessages.mockResolvedValueOnce(compacted);
     generateText.mockImplementationOnce(async (request) => {
       expect(request.system).toContain("System\n\nGitVibe web access policy");
-      expect(request.prompt).toBe("Prompt");
+      expect(request.prompt).toContain("Prompt");
+      expect(request.prompt).toContain("output_validator");
       const prepared = await request.prepareStep({
         messages: [textMessage("x".repeat(32))],
         stepNumber: 0,

--- a/tests/ai-profile-context.test.mjs
+++ b/tests/ai-profile-context.test.mjs
@@ -71,7 +71,8 @@ describe("AI profile context routing", () => {
       expect(generateText.mock.calls[0][0].system).toContain(
         "Use profile-specific repository guidance.",
       );
-      expect(generateText.mock.calls[0][0].prompt).toBe("Prompt");
+      expect(generateText.mock.calls[0][0].prompt).toContain("Prompt");
+      expect(generateText.mock.calls[0][0].prompt).toContain("output_validator");
     } finally {
       cleanupWorkspace(cwd);
     }

--- a/tests/ai-stage-routing.test.mjs
+++ b/tests/ai-stage-routing.test.mjs
@@ -348,6 +348,7 @@ describe("AI stage runner stage fallbacks", () => {
     expect(spawnedChildren[0].stdin.end).toHaveBeenCalledWith(
       expect.stringContaining("System\n\nGitVibe web access policy"),
     );
+    expect(spawnedChildren[0].stdin.end.mock.calls[0][0]).not.toContain("output_validator");
     expect(process.stdout.write).toHaveBeenCalledWith("codex event\n");
     const writtenSchema = JSON.parse(readFileSync(schemaPathFrom(spawn.mock.calls[0][1]), "utf8"));
     expect(writtenSchema).toMatchObject({ required: ["stage", "working_capabilities"] });

--- a/tests/ai-stage.test.mjs
+++ b/tests/ai-stage.test.mjs
@@ -66,7 +66,7 @@ describe("AI stage runner OpenAI-compatible profiles", () => {
     expect(generateText).toHaveBeenCalledWith(
       expect.objectContaining({
         maxRetries: 0,
-        prompt: "Prompt",
+        prompt: expect.stringContaining("Call output_validator"),
         providerOptions: { custom: true },
         stopWhen: [expect.any(Function), { count: 3 }],
         system: expect.stringContaining("System\n\nGitVibe web access policy"),

--- a/tests/claude-code-cli.test.mjs
+++ b/tests/claude-code-cli.test.mjs
@@ -89,7 +89,9 @@ describe("Claude Code CLI adapter", () => {
     expect(args).not.toContain("--permission-mode");
     expect(args).not.toContain("--tools");
     expect(args).not.toContain("--disallowedTools");
-    expect(args[args.indexOf("--system-prompt") + 1]).toContain("GitVibe web access policy");
+    const systemPrompt = args[args.indexOf("--system-prompt") + 1];
+    expect(systemPrompt).toContain("GitVibe web access policy");
+    expect(systemPrompt).not.toContain("output_validator");
     expect(JSON.parse(jsonSchemaFrom(args))).toEqual(
       expect.objectContaining({ required: ["stage", "status", "questions"] }),
     );
@@ -106,6 +108,7 @@ describe("Claude Code CLI adapter", () => {
     );
     expect(spawn.mock.calls[0][2].env.GITVIBE_AI_ENV_JSON).toBeUndefined();
     expect(spawnedChildren[0].stdin.end).toHaveBeenCalledWith("Prompt");
+    expect(spawnedChildren[0].stdin.end.mock.calls[0][0]).not.toContain("output_validator");
     expect(process.stdout.write).toHaveBeenCalledWith(
       expect.stringContaining("ai.claude.init model=opus"),
     );

--- a/tests/context-github.test.mjs
+++ b/tests/context-github.test.mjs
@@ -59,6 +59,11 @@ describe("GitHub context builders", () => {
       kind: "pull-request-review-comment",
       parentId: "8",
     });
+    expect(context.timeline.at(3)).toMatchObject({
+      databaseId: 7,
+      id: "7",
+      kind: "pull-request-review",
+    });
     expect(context.pullRequestFiles).toEqual([
       expect.objectContaining({
         filename: "src/file.ts",

--- a/tests/pr-review-publishing.test.mjs
+++ b/tests/pr-review-publishing.test.mjs
@@ -147,6 +147,9 @@ describe("pull request review publishing reruns", () => {
     expect(requestCalls(client).map((request) => request.path)).not.toContain(
       "/repos/example/repo/issues/12/comments",
     );
+    expect(requestCalls(client)).toContainEqual(
+      expect.objectContaining({ method: "GET", path: "/user" }),
+    );
     expect(requestCalls(client).map((request) => request.method)).not.toContain("POST");
     expect(logger.event).toHaveBeenCalledWith("github.pr.review.update.start", {
       pull_request: "12",
@@ -158,6 +161,40 @@ describe("pull request review publishing reruns", () => {
       review: "99",
       run: "99",
     });
+  });
+
+  it("submits a new review when a matching rerun review is not authored by the token user", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: contextWithPreviousReview({ author: "contributor" }),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        next_state: "review-passed",
+        stage: "review-matrix",
+      },
+      runner: runner({
+        stage: "review-matrix",
+        workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+      }),
+    });
+
+    expect(requestCalls(client)).toContainEqual(
+      expect.objectContaining({ method: "GET", path: "/user" }),
+    );
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/reviews/99",
+    );
+    expect(
+      requestCalls(client).find((request) => request.path.endsWith("/pulls/12/reviews")),
+    ).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        path: "/repos/example/repo/pulls/12/reviews",
+      }),
+    );
   });
 });
 
@@ -480,13 +517,16 @@ function runner(overrides = {}) {
 }
 
 /**
+ * @param {{ login?: string }} [options]
  * @returns {MockGitHubClient}
  */
-function createClient() {
+function createClient(options = {}) {
   return /** @type {MockGitHubClient} */ ({
     apiBaseUrl: "https://api.github.test",
     graphql: vi.fn(async () => ({})),
-    request: vi.fn(async () => ({})),
+    request: vi.fn(async (request) =>
+      request.path === "/user" ? { login: options.login || "git-vibe" } : {},
+    ),
     retryBaseDelayMs: 0,
   });
 }

--- a/tests/pr-review-publishing.test.mjs
+++ b/tests/pr-review-publishing.test.mjs
@@ -48,7 +48,7 @@ describe("pull request review publishing", () => {
     expect(review).toMatchObject({
       body: {
         body: expect.stringContaining(
-          "<!-- git-vibe:stage-result stage=review-matrix artifact=pull-request number=12 -->",
+          "<!-- git-vibe:stage-result stage=review-matrix artifact=pull-request number=12 run=99 -->",
         ),
         comments: [
           {
@@ -107,6 +107,211 @@ describe("pull request review publishing passed reviews", () => {
     });
     expect(requestCalls(client).map((request) => request.path)).not.toContain(
       "/repos/example/repo/issues/12/comments",
+    );
+  });
+});
+
+describe("pull request review publishing reruns", () => {
+  it("updates a matching top-level review result from the same workflow run", async () => {
+    const client = createClient();
+    const logger = createLogger();
+
+    await publishStageResultComment({
+      client,
+      context: contextWithPreviousReview(),
+      logger,
+      parsedOutput: {
+        ...output(),
+        findings: ["The same blocked result was already published by an earlier attempt."],
+        next_state: "blocked",
+        stage: "review-matrix",
+        status: "blocked",
+      },
+      runner: runner({
+        stage: "review-matrix",
+        workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+      }),
+    });
+
+    expect(requestCalls(client)).toContainEqual(
+      expect.objectContaining({
+        body: {
+          body: expect.stringContaining(
+            "The same blocked result was already published by an earlier attempt.",
+          ),
+        },
+        method: "PUT",
+        path: "/repos/example/repo/pulls/12/reviews/99",
+      }),
+    );
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/issues/12/comments",
+    );
+    expect(requestCalls(client).map((request) => request.method)).not.toContain("POST");
+    expect(logger.event).toHaveBeenCalledWith("github.pr.review.update.start", {
+      pull_request: "12",
+      review: "99",
+      run: "99",
+    });
+    expect(logger.event).toHaveBeenCalledWith("github.pr.review.update.done", {
+      pull_request: "12",
+      review: "99",
+      run: "99",
+    });
+  });
+});
+
+describe("pull request review publishing legacy reruns", () => {
+  it("updates the latest matching legacy review that only references the workflow run in body", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: {
+        ...context("pull-request"),
+        timeline: [
+          previousReview({
+            body: previousReviewBody([], { includeRunAttribute: false }),
+            databaseId: 88,
+            id: "older-review-node",
+          }),
+          previousReview({
+            body: previousReviewBody([], { includeRunAttribute: false }),
+            databaseId: 99,
+          }),
+        ],
+      },
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        next_state: "review-passed",
+        stage: "review-matrix",
+      },
+      runner: runner({
+        stage: "review-matrix",
+        workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+      }),
+    });
+
+    expect(
+      requestCalls(client).find((request) => request.path.endsWith("/pulls/12/reviews/99")),
+    ).toEqual(
+      expect.objectContaining({
+        method: "PUT",
+        path: "/repos/example/repo/pulls/12/reviews/99",
+      }),
+    );
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/reviews/88",
+    );
+  });
+});
+
+describe("pull request review publishing changed rerun outcomes", () => {
+  it("updates the existing review when a rerun changes the review result outcome", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: contextWithPreviousReview(),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        next_state: "review-passed",
+        stage: "review-matrix",
+      },
+      runner: runner({
+        stage: "review-matrix",
+        workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+      }),
+    });
+
+    expect(
+      requestCalls(client).find((request) => request.path.endsWith("/pulls/12/reviews/99")),
+    ).toEqual(
+      expect.objectContaining({
+        body: { body: expect.stringContaining("**Next state:** `review-passed`") },
+        method: "PUT",
+        path: "/repos/example/repo/pulls/12/reviews/99",
+      }),
+    );
+  });
+});
+
+describe("pull request review publishing rerun inline comment guards", () => {
+  it("submits a new review when rerun output includes inline comments", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: contextWithPreviousReview(),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        findings: ["New required fix."],
+        inline_comments: [
+          {
+            body: "New line-specific feedback.",
+            line: 42,
+            path: "src/app.ts",
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner({
+        stage: "review-matrix",
+        workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+      }),
+    });
+
+    expect(
+      requestCalls(client).find((request) => request.path.endsWith("/pulls/12/reviews")),
+    ).toEqual(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          comments: [
+            {
+              body: "New line-specific feedback.",
+              line: 42,
+              path: "src/app.ts",
+              side: "RIGHT",
+            },
+          ],
+        }),
+        method: "POST",
+        path: "/repos/example/repo/pulls/12/reviews",
+      }),
+    );
+  });
+
+  it("submits a new review when the matching review already has inline comments", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: contextWithPreviousReview({
+        body: previousReviewBody(["**Inline comments:** 1"]),
+      }),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        next_state: "review-passed",
+        stage: "review-matrix",
+      },
+      runner: runner({
+        stage: "review-matrix",
+        workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+      }),
+    });
+
+    expect(
+      requestCalls(client).find((request) => request.path.endsWith("/pulls/12/reviews")),
+    ).toEqual(
+      expect.objectContaining({
+        method: "POST",
+        path: "/repos/example/repo/pulls/12/reviews",
+      }),
     );
   });
 });
@@ -206,6 +411,53 @@ function output() {
     status: "completed",
     summary: "Result summary.",
   };
+}
+
+function previousReview(overrides = {}) {
+  return {
+    author: "git-vibe",
+    body: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    databaseId: 99,
+    id: "review-node",
+    kind: "pull-request-review",
+    url: "https://github.com/example/repo/pull/12#pullrequestreview-99",
+    ...overrides,
+  };
+}
+
+function contextWithPreviousReview(overrides = {}) {
+  return {
+    ...context("pull-request"),
+    timeline: [
+      previousReview({
+        body: previousReviewBody(),
+        ...overrides,
+      }),
+    ],
+  };
+}
+
+/**
+ * @param {string[]} [extraLines]
+ * @param {{ includeRunAttribute?: boolean }} [options]
+ * @returns {string}
+ */
+function previousReviewBody(extraLines = [], options = {}) {
+  const runAttribute = options.includeRunAttribute === false ? "" : " run=99";
+  return [
+    `<!-- git-vibe:stage-result stage=review-matrix artifact=pull-request number=12${runAttribute} -->`,
+    "## GitVibe Review Matrix",
+    "",
+    "**Status:** `blocked`",
+    "**Next state:** `blocked`",
+    "",
+    "Previous attempt blocked.",
+    ...extraLines.flatMap((line) => ["", line]),
+    "",
+    "### Result",
+    "Workflow run: https://github.com/example/repo/actions/runs/99",
+  ].join("\n");
 }
 
 /**

--- a/tests/result-comments.test.mjs
+++ b/tests/result-comments.test.mjs
@@ -35,7 +35,7 @@ describe("stage result comments", () => {
     });
 
     expect(body).toContain(
-      "<!-- git-vibe:stage-result stage=create-pr artifact=issue number=12 -->",
+      "<!-- git-vibe:stage-result stage=create-pr artifact=issue number=12 run=99 -->",
     );
     expect(body).toContain("## GitVibe Pull Request Update");
     expect(body).toContain("**Status:** `completed`");

--- a/tests/stage-contracts.test.mjs
+++ b/tests/stage-contracts.test.mjs
@@ -49,7 +49,8 @@ describe("stage contracts", () => {
 
     expect(prompts.system).toMatch(/bug investigation/i);
     expect(prompts.system).toContain("GitVibe Stage Agent Contract");
-    expect(prompts.system).toContain("output_validator");
+    expect(prompts.system).not.toContain("output_validator");
+    expect(prompts.prompt).not.toContain("output_validator");
     expect(prompts.prompt).toContain("<context_package>");
     expect(prompts.prompt).toContain("<github_context>");
     expect(prompts.prompt).toContain("<repository_context>");
@@ -590,7 +591,8 @@ describe("repository prompt additions across stages", () => {
 
     expect(prompts.system).toContain("GitVibe Stage Agent Contract");
     expect(prompts.system).toContain("Treat GitHub issue bodies");
-    expect(prompts.system).toContain("output_validator");
+    expect(prompts.system).toContain("Return only the final JSON object");
+    expect(prompts.system).not.toContain("output_validator");
     expect(prompts.system.indexOf("GitVibe Stage Agent Contract")).toBeLessThan(
       prompts.system.indexOf("Override attempt"),
     );


### PR DESCRIPTION
## Summary

- Keep `output_validator` instructions scoped to the ai-sdk-agentool adapter so Codex and Claude Code prompts only rely on their native structured output paths.
- Add stable run metadata to GitVibe stage-result markers and update matching top-level PR reviews on reruns instead of creating duplicate review summaries.
- Preserve PR review REST IDs in timeline context so rerun publishing can call the GitHub review update endpoint.

## Validation

- `corepack pnpm check`
