### PR TITLE
[codex] Reconcile GitVibe PR review threads

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,3 +6,5 @@ reviews:
     base_branches:
       - "^main$"
       - "^dev$"
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0

--- a/prompts/review-matrix/user.md
+++ b/prompts/review-matrix/user.md
@@ -18,6 +18,7 @@ Review the proposed pull request or merge-preparation change. Report only valida
 - Do not report preferences, speculative improvements, over-engineering requests, or broad refactors as blockers.
 - If required fixes exist, keep `status` as `completed`, set `next_state` to `changes-required`, and put only actionable required fixes in `findings`.
 - For each required fix that can be anchored to an exact changed pull request diff line, add a matching `inline_comments` item with `path`, right-side `line`, and a concise `body` that explains the failure and required fix. Use `start_line` only for a contiguous range on the same side. Do not invent anchors; keep unanchored blockers in `findings` and `comment_body`.
+- If an existing GitVibe inline review comment contains a hidden `git-vibe:review-finding id=...` marker and the same issue still applies, set the new `inline_comments` item `finding_id` to that id. Do not copy hidden markers into `body`.
 - If no required fix exists, say so in `summary`, keep `findings` empty, and set `next_state` to `review-passed`.
 - Use `blocked` only when the review itself cannot be completed or a maintainer decision is required before code can continue.
   </finding_standard>
@@ -26,7 +27,7 @@ Review the proposed pull request or merge-preparation change. Report only valida
 
 - `tests`: Review-relevant checks observed or recommended.
 - `findings`: Blocking issues only, ordered by severity.
-- `inline_comments`: GitHub PR review comments for blocking findings that have exact changed-line anchors. Leave empty or omit when there are no anchorable blockers.
+- `inline_comments`: GitHub PR review comments for blocking findings that have exact changed-line anchors. Reuse `finding_id` from an existing GitVibe marker when reporting the same issue again. Leave empty or omit when there are no anchorable blockers.
 - `questions`: Maintainer decisions required before code can continue, preferably as answerable question objects with up to four options.
 - `next_state`: Use `review-passed` when the PR can proceed to approval, `changes-required` when implementation must address evidence-backed findings before the PR is ready for approval, or `blocked` when automation must stop.
   </required_fields_guidance>

--- a/schemas/stages/review-matrix.v1.schema.json
+++ b/schemas/stages/review-matrix.v1.schema.json
@@ -31,6 +31,10 @@
           "line": { "type": "integer", "minimum": 1 },
           "start_line": { "type": "integer", "minimum": 1 },
           "side": { "type": "string", "enum": ["LEFT", "RIGHT"] },
+          "finding_id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$"
+          },
           "body": { "type": "string", "minLength": 1 },
           "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] }
         }

--- a/src/runner/content-units.ts
+++ b/src/runner/content-units.ts
@@ -480,6 +480,8 @@ function packedTimelineItem(item: TimelineItem, index: number): JsonObject {
     kind: item.kind,
     parentId: item.parentId,
     reactions: item.reactions,
+    reviewThreadId: item.reviewThreadId,
+    reviewThreadIsOutdated: item.reviewThreadIsOutdated,
     url: item.url,
   };
 }

--- a/src/runner/context-graphql.ts
+++ b/src/runner/context-graphql.ts
@@ -22,6 +22,8 @@ export interface PullRequestReviewCommentNode {
   id: string;
   path?: string;
   replyTo?: { id?: string } | null;
+  reviewThreadId?: string;
+  reviewThreadIsOutdated?: boolean;
   updatedAt?: string;
   url?: string;
 }
@@ -130,9 +132,14 @@ export async function openPullRequestReviewComments(options: {
     token: options.token,
   });
   return threads
-    .filter((thread) => !thread.isResolved && !thread.isOutdated)
+    .filter((thread) => !thread.isResolved)
     .flatMap((thread) =>
-      thread.comments.nodes.map((comment) => ({ ...comment, path: comment.path || thread.path })),
+      thread.comments.nodes.map((comment) => ({
+        ...comment,
+        path: comment.path || thread.path,
+        reviewThreadId: thread.id,
+        reviewThreadIsOutdated: thread.isOutdated,
+      })),
     );
 }
 

--- a/src/runner/context-graphql.ts
+++ b/src/runner/context-graphql.ts
@@ -403,6 +403,7 @@ const pullRequestReviewThreadsQuery = `
               pageInfo { hasNextPage endCursor }
               nodes {
                 id
+                databaseId
                 body
                 createdAt
                 updatedAt
@@ -429,6 +430,7 @@ const pullRequestReviewThreadCommentsQuery = `
           pageInfo { hasNextPage endCursor }
           nodes {
             id
+            databaseId
             body
             createdAt
             updatedAt

--- a/src/runner/context.ts
+++ b/src/runner/context.ts
@@ -441,6 +441,8 @@ function toPullRequestReviewTimelineItem(item: PullRequestReviewCommentNode): Ti
     authorAssociation: item.authorAssociation,
     databaseId: item.databaseId,
     parentId: item.replyTo?.id ? String(item.replyTo.id) : undefined,
+    reviewThreadId: item.reviewThreadId,
+    reviewThreadIsOutdated: item.reviewThreadIsOutdated,
   };
 }
 

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { GitHubClient, splitRepository } from "../shared/github.js";
 import { workflowRunIdFromUrl } from "../shared/status-comments.js";
 import type { ContextPacket, JsonObject, RunnerOptions } from "../shared/types.js";
@@ -12,9 +13,29 @@ interface PullRequestReviewComment {
   start_side?: "LEFT" | "RIGHT";
 }
 
+interface ReviewFindingComment {
+  body: string;
+  findingId: string;
+  reviewComment: PullRequestReviewComment;
+}
+
+interface PriorReviewFinding {
+  commentDatabaseId: string;
+  findingId: string;
+  reviewThreadId: string;
+  updateKeys: Set<string>;
+}
+
 interface AuthenticatedUserResponse extends JsonObject {
   login?: string;
 }
+
+interface ReviewedCommit {
+  label: string;
+  markerSha: string;
+}
+
+type ReviewFindingUpdateStatus = "outdated" | "still-present";
 
 export async function publishPullRequestReviewResult(options: {
   client: GitHubClient;
@@ -26,7 +47,9 @@ export async function publishPullRequestReviewResult(options: {
 }): Promise<boolean> {
   if (!shouldPublishPullRequestReview(options)) return false;
 
-  const comments = inlineReviewComments(options.parsedOutput.inline_comments);
+  const findings = reviewFindingComments(options.parsedOutput.inline_comments);
+  const reconciliation = await reconcileReviewFindings({ ...options, findings });
+  const comments = reconciliation.newFindings.map((finding) => finding.reviewComment);
   const body = pullRequestReviewBody({
     comments,
     output: options.parsedOutput,
@@ -115,6 +138,7 @@ async function editableReviewForStageResult(options: {
 
   const login = await authenticatedGitHubLogin({
     client: options.client,
+    eventName: "github.pr.review.update.skip",
     logger: options.logger,
     token: options.runner.token,
   });
@@ -131,14 +155,7 @@ async function editableReviewForStageResult(options: {
 function parseStageResultMarker(
   body: string,
 ): { artifact: string; number: string; run?: string; stage: string } | undefined {
-  const match = body.match(/<!--\s*git-vibe:stage-result\s+([^>]*)-->/);
-  if (!match) return undefined;
-  const attributes = Object.fromEntries(
-    [...(match[1] || "").matchAll(/([a-z][a-z-]*)=([^\s>]+)/g)].map((entry) => [
-      entry[1],
-      entry[2],
-    ]),
-  );
+  const attributes = markerAttributes(body, "git-vibe:stage-result");
   if (!attributes.stage || !attributes.artifact || !attributes.number) return undefined;
   return {
     artifact: attributes.artifact,
@@ -170,6 +187,7 @@ function sameGitHubLogin(left: string, right: string): boolean {
 
 async function authenticatedGitHubLogin(options: {
   client: GitHubClient;
+  eventName: string;
   logger: StageLogger;
   token: string;
 }): Promise<string | undefined> {
@@ -181,14 +199,14 @@ async function authenticatedGitHubLogin(options: {
       token: options.token,
     });
   } catch {
-    options.logger.event("github.pr.review.update.skip", {
+    options.logger.event(options.eventName, {
       reason: "unknown-token-author",
     });
     return undefined;
   }
   const login = stringField(user.login);
   if (!login) {
-    options.logger.event("github.pr.review.update.skip", {
+    options.logger.event(options.eventName, {
       reason: "unknown-token-author",
     });
     return undefined;
@@ -234,27 +252,222 @@ async function updatePullRequestReview(options: {
   });
 }
 
-function inlineReviewComments(value: unknown): PullRequestReviewComment[] {
+async function reconcileReviewFindings(options: {
+  client: GitHubClient;
+  context: ContextPacket;
+  findings: ReviewFindingComment[];
+  logger: StageLogger;
+  runner: RunnerOptions;
+}): Promise<{ newFindings: ReviewFindingComment[] }> {
+  const priorFindings = await priorReviewFindings(options);
+  if (!priorFindings.size) return { newFindings: options.findings };
+
+  const commit = reviewedCommit(options.context);
+  const currentFindingIds = new Set(options.findings.map((finding) => finding.findingId));
+  const newFindings: ReviewFindingComment[] = [];
+
+  for (const finding of options.findings) {
+    const prior = priorFindings.get(finding.findingId);
+    if (!prior) {
+      newFindings.push(finding);
+      continue;
+    }
+    await replyToPriorReviewFinding({
+      ...options,
+      body: stillPresentReviewFindingReply(finding.body, commit.label),
+      commit,
+      prior,
+      status: "still-present",
+    });
+  }
+
+  for (const prior of priorFindings.values()) {
+    if (currentFindingIds.has(prior.findingId)) continue;
+    await replyToPriorReviewFinding({
+      ...options,
+      body: outdatedReviewFindingReply(commit.label),
+      commit,
+      prior,
+      status: "outdated",
+    });
+    await resolveReviewThread({
+      client: options.client,
+      logger: options.logger,
+      reviewThreadId: prior.reviewThreadId,
+      token: options.runner.token,
+    });
+  }
+
+  return { newFindings };
+}
+
+async function priorReviewFindings(options: {
+  client: GitHubClient;
+  context: ContextPacket;
+  logger: StageLogger;
+  runner: RunnerOptions;
+}): Promise<Map<string, PriorReviewFinding>> {
+  const candidates = priorReviewFindingCandidates(options.context);
+  if (!candidates.length) return new Map();
+
+  const login = await authenticatedGitHubLogin({
+    client: options.client,
+    eventName: "github.pr.review_thread.reconcile.skip",
+    logger: options.logger,
+    token: options.runner.token,
+  });
+  if (!login) return new Map();
+
+  const findings = new Map<string, PriorReviewFinding>();
+  const updates = reviewFindingUpdatesByThread(options.context);
+  for (const candidate of candidates) {
+    if (!sameGitHubLogin(candidate.author, login)) continue;
+    findings.set(candidate.findingId, {
+      ...candidate,
+      updateKeys: updates.get(candidate.reviewThreadId) || new Set(),
+    });
+  }
+  return findings;
+}
+
+function priorReviewFindingCandidates(
+  context: ContextPacket,
+): Array<Omit<PriorReviewFinding, "updateKeys"> & { author: string }> {
+  const candidates: Array<Omit<PriorReviewFinding, "updateKeys"> & { author: string }> = [];
+  for (const item of context.timeline) {
+    if (item.kind !== "pull-request-review-comment" || item.parentId) continue;
+    const findingId = parseReviewFindingMarker(item.body)?.id;
+    const reviewThreadId = stringField(item.reviewThreadId);
+    const commentDatabaseId = reviewCommentDatabaseId(item.databaseId);
+    if (!findingId || !reviewThreadId || !commentDatabaseId) continue;
+    candidates.push({
+      author: item.author,
+      commentDatabaseId,
+      findingId,
+      reviewThreadId,
+    });
+  }
+  return candidates;
+}
+
+function reviewFindingUpdatesByThread(context: ContextPacket): Map<string, Set<string>> {
+  const updates = new Map<string, Set<string>>();
+  for (const item of context.timeline) {
+    if (item.kind !== "pull-request-review-comment" || !item.reviewThreadId) continue;
+    const marker = parseReviewFindingUpdateMarker(item.body);
+    if (!marker) continue;
+    const key = reviewFindingUpdateKey(marker);
+    const threadUpdates = updates.get(item.reviewThreadId) || new Set<string>();
+    threadUpdates.add(key);
+    updates.set(item.reviewThreadId, threadUpdates);
+  }
+  return updates;
+}
+
+async function replyToPriorReviewFinding(options: {
+  body: string;
+  client: GitHubClient;
+  commit: ReviewedCommit;
+  context: ContextPacket;
+  logger: StageLogger;
+  prior: PriorReviewFinding;
+  runner: RunnerOptions;
+  status: ReviewFindingUpdateStatus;
+}): Promise<void> {
+  const update = {
+    id: options.prior.findingId,
+    sha: options.commit.markerSha,
+    status: options.status,
+  };
+  const updateKey = reviewFindingUpdateKey(update);
+  if (options.prior.updateKeys.has(updateKey)) {
+    options.logger.event("github.pr.review_thread.reply.skip", {
+      finding: options.prior.findingId,
+      reason: "duplicate-update",
+      status: options.status,
+    });
+    return;
+  }
+
+  options.logger.event("github.pr.review_thread.reply.start", {
+    finding: options.prior.findingId,
+    pull_request: options.context.artifact.number,
+    status: options.status,
+  });
+  await createPullRequestReviewReply({
+    body: `${reviewFindingUpdateMarker(update)}\n${options.body}`,
+    client: options.client,
+    commentId: options.prior.commentDatabaseId,
+    pullNumber: options.context.artifact.number,
+    repository: options.runner.repository,
+    token: options.runner.token,
+  });
+  options.prior.updateKeys.add(updateKey);
+  options.logger.event("github.pr.review_thread.reply.done", {
+    finding: options.prior.findingId,
+    pull_request: options.context.artifact.number,
+    status: options.status,
+  });
+}
+
+async function createPullRequestReviewReply(options: {
+  body: string;
+  client: GitHubClient;
+  commentId: string;
+  pullNumber: string;
+  repository: string;
+  token: string;
+}): Promise<void> {
+  const { owner, repo } = splitRepository(options.repository);
+  await options.client.request({
+    body: { body: options.body },
+    method: "POST",
+    path: `/repos/${owner}/${repo}/pulls/${options.pullNumber}/comments/${options.commentId}/replies`,
+    token: options.token,
+  });
+}
+
+async function resolveReviewThread(options: {
+  client: GitHubClient;
+  logger: StageLogger;
+  reviewThreadId: string;
+  token: string;
+}): Promise<void> {
+  options.logger.event("github.pr.review_thread.resolve.start", {
+    thread: options.reviewThreadId,
+  });
+  await options.client.graphql(
+    resolveReviewThreadMutation,
+    { threadId: options.reviewThreadId },
+    options.token,
+  );
+  options.logger.event("github.pr.review_thread.resolve.done", {
+    thread: options.reviewThreadId,
+  });
+}
+
+function reviewFindingComments(value: unknown): ReviewFindingComment[] {
   if (value === undefined) return [];
   if (!Array.isArray(value)) {
     throw new Error("review-matrix inline_comments must be an array.");
   }
-  return value.map((item, index) => inlineReviewComment(item, index));
+  return value.map((item, index) => reviewFindingComment(item, index));
 }
 
-function inlineReviewComment(value: unknown, index: number): PullRequestReviewComment {
+function reviewFindingComment(value: unknown, index: number): ReviewFindingComment {
   if (!isRecord(value)) {
     throw new Error(`review-matrix inline_comments[${index}] must be an object.`);
   }
   const path = stringField(value.path);
-  const body = stringField(value.body);
+  const rawBody = stringField(value.body);
+  const body = visibleReviewCommentBody(rawBody);
   const line = integerField(value.line);
   if (!path || !body || line === undefined) {
     throw new Error(`review-matrix inline_comments[${index}] must define path, line, and body.`);
   }
 
   const side = sideField(value.side);
-  const comment: PullRequestReviewComment = { body, line, path, side };
+  const reviewComment: PullRequestReviewComment = { body, line, path, side };
   const startLine = integerField(value.start_line);
   if (startLine !== undefined) {
     if (startLine > line) {
@@ -262,10 +475,111 @@ function inlineReviewComment(value: unknown, index: number): PullRequestReviewCo
         `review-matrix inline_comments[${index}].start_line must be less than or equal to line.`,
       );
     }
-    comment.start_line = startLine;
-    comment.start_side = side;
+    reviewComment.start_line = startLine;
+    reviewComment.start_side = side;
   }
-  return comment;
+  const findingId =
+    normalizedFindingId(value.finding_id) ||
+    parseReviewFindingMarker(rawBody)?.id ||
+    generatedFindingId({ body, line, path, startLine });
+  reviewComment.body = `${reviewFindingMarker(findingId)}\n${body}`;
+  return { body, findingId, reviewComment };
+}
+
+function reviewFindingMarker(id: string): string {
+  return `<!-- git-vibe:review-finding id=${id} -->`;
+}
+
+function reviewFindingUpdateMarker(options: {
+  id: string;
+  sha: string;
+  status: ReviewFindingUpdateStatus;
+}): string {
+  return `<!-- git-vibe:review-finding-update id=${options.id} status=${options.status} sha=${options.sha} -->`;
+}
+
+function parseReviewFindingMarker(body: string): { id: string } | undefined {
+  const id = normalizedFindingId(markerAttributes(body, "git-vibe:review-finding").id);
+  return id ? { id } : undefined;
+}
+
+function parseReviewFindingUpdateMarker(
+  body: string,
+): { id: string; sha: string; status: ReviewFindingUpdateStatus } | undefined {
+  const attributes = markerAttributes(body, "git-vibe:review-finding-update");
+  const id = normalizedFindingId(attributes.id);
+  const sha = normalizedFindingMarkerValue(attributes.sha);
+  const status = reviewFindingUpdateStatus(attributes.status);
+  if (!id || !sha || !status) return undefined;
+  return { id, sha, status };
+}
+
+function markerAttributes(body: string, marker: string): Record<string, string> {
+  const match = body.match(new RegExp(`<!--\\s*${marker}\\s+([^>]*)-->`));
+  if (!match) return {};
+  return Object.fromEntries(
+    [...(match[1] || "").matchAll(/([a-z][a-z-]*)=([^\s>]+)/g)].map((entry) => [
+      entry[1],
+      entry[2],
+    ]),
+  );
+}
+
+function reviewFindingUpdateStatus(value: unknown): ReviewFindingUpdateStatus | undefined {
+  return value === "outdated" || value === "still-present" ? value : undefined;
+}
+
+function reviewFindingUpdateKey(options: {
+  id: string;
+  sha: string;
+  status: ReviewFindingUpdateStatus;
+}): string {
+  return `${options.id}:${options.status}:${options.sha}`;
+}
+
+function visibleReviewCommentBody(body: string): string {
+  return body.replace(/<!--\s*git-vibe:review-finding(?:-update)?\s+[^>]*-->\s*/g, "").trim();
+}
+
+function generatedFindingId(options: {
+  body: string;
+  line: number;
+  path: string;
+  startLine?: number;
+}): string {
+  const fingerprint = [options.path, options.startLine || "", options.line, options.body]
+    .map((part) => String(part).trim())
+    .join("\0");
+  return `gv-${createHash("sha256").update(fingerprint).digest("hex").slice(0, 16)}`;
+}
+
+function normalizedFindingId(value: unknown): string | undefined {
+  const id = stringField(value);
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/.test(id) ? id : undefined;
+}
+
+function normalizedFindingMarkerValue(value: unknown): string | undefined {
+  const markerValue = stringField(value);
+  return /^[A-Za-z0-9._:-]+$/.test(markerValue) ? markerValue : undefined;
+}
+
+function reviewCommentDatabaseId(value: number | string | undefined): string | undefined {
+  return reviewDatabaseId(value);
+}
+
+function reviewedCommit(context: ContextPacket): ReviewedCommit {
+  const sha = stringField(context.artifact.pullRequestHead?.sha);
+  if (!sha) return { label: "the latest reviewed commit", markerSha: "latest" };
+  const shortSha = sha.slice(0, 12);
+  return { label: `commit \`${shortSha}\``, markerSha: shortSha };
+}
+
+function stillPresentReviewFindingReply(body: string, commitLabel: string): string {
+  return cleanLines([`This issue still exists after ${commitLabel}.`, "", body]).join("\n");
+}
+
+function outdatedReviewFindingReply(commitLabel: string): string {
+  return `This GitVibe finding is outdated after ${commitLabel}; the latest review no longer reports this issue.`;
 }
 
 function pullRequestReviewBody(options: {
@@ -338,3 +652,13 @@ function cleanLines(lines: string[]): string[] {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+const resolveReviewThreadMutation = `
+  mutation GitVibeResolveReviewThread($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread {
+        id
+      }
+    }
+  }
+`;

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -319,7 +319,7 @@ async function priorReviewFindings(options: {
   if (!login) return new Map();
 
   const findings = new Map<string, PriorReviewFinding>();
-  const updates = reviewFindingUpdatesByThread(options.context);
+  const updates = reviewFindingUpdatesByThread(options.context, login);
   for (const candidate of candidates) {
     if (!sameGitHubLogin(candidate.author, login)) continue;
     findings.set(candidate.findingId, {
@@ -350,10 +350,14 @@ function priorReviewFindingCandidates(
   return candidates;
 }
 
-function reviewFindingUpdatesByThread(context: ContextPacket): Map<string, Set<string>> {
+function reviewFindingUpdatesByThread(
+  context: ContextPacket,
+  login: string,
+): Map<string, Set<string>> {
   const updates = new Map<string, Set<string>>();
   for (const item of context.timeline) {
     if (item.kind !== "pull-request-review-comment" || !item.reviewThreadId) continue;
+    if (!sameGitHubLogin(item.author, login)) continue;
     const marker = parseReviewFindingUpdateMarker(item.body);
     if (!marker) continue;
     const key = reviewFindingUpdateKey(marker);

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -48,8 +48,10 @@ export async function publishPullRequestReviewResult(options: {
   if (!shouldPublishPullRequestReview(options)) return false;
 
   const findings = reviewFindingComments(options.parsedOutput.inline_comments);
-  const reconciliation = await reconcileReviewFindings({ ...options, findings });
-  const comments = reconciliation.newFindings.map((finding) => finding.reviewComment);
+  const newFindings = shouldReconcileReviewFindings(options.parsedOutput)
+    ? (await reconcileReviewFindings({ ...options, findings })).newFindings
+    : findings;
+  const comments = newFindings.map((finding) => finding.reviewComment);
   const body = pullRequestReviewBody({
     comments,
     output: options.parsedOutput,
@@ -105,6 +107,14 @@ function shouldPublishPullRequestReview(options: {
 }): boolean {
   return (
     options.runner.stage === "review-matrix" && options.context.artifact.type === "pull-request"
+  );
+}
+
+function shouldReconcileReviewFindings(output: JsonObject): boolean {
+  return (
+    String(output.status || "")
+      .trim()
+      .toLowerCase() === "completed"
   );
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,6 +75,8 @@ export interface TimelineItem {
   kind: string;
   parentId?: string;
   reactions?: JsonObject;
+  reviewThreadId?: string;
+  reviewThreadIsOutdated?: boolean;
   updatedAt?: string;
   url: string;
 }

--- a/tests/context-github.test.mjs
+++ b/tests/context-github.test.mjs
@@ -33,13 +33,7 @@ describe("GitHub context builders", () => {
   it("builds issue context from issue body and sorted comments", async () => {
     const client = pullRequestContextClient();
 
-    const context = await buildIssueContext({
-      client,
-      issueNumber: "4",
-      repository: "example/repo",
-      token: "token",
-      type: "pull-request",
-    });
+    const context = await buildPullRequestContext(client);
 
     expect(context.artifact).toMatchObject({
       labels: ["git-vibe:accept-risk", "custom"],
@@ -54,12 +48,15 @@ describe("GitHub context builders", () => {
       "Second",
       "<!-- git-vibe:stage-result stage=review-matrix artifact=pull-request number=4 -->\n## GitVibe Review Matrix",
       "Path: src/file.ts\nDiff:\n@@ -1 +1 @@\n\nReview feedback",
+      "Path: src/old.ts\nOutdated feedback",
     ]);
     expect(context.timeline.at(-1)).toMatchObject({
-      id: "9",
-      kind: "pull-request-review-comment",
+      reviewThreadId: "thread-11",
+      reviewThreadIsOutdated: true,
+    });
+    expect(context.timeline.at(-2)).toMatchObject({
       parentId: "8",
-      updatedAt: "2026-01-05T01:00:00Z",
+      reviewThreadId: "thread-9",
     });
     expect(context.artifact.updatedAt).toBe("2026-01-06T00:00:00Z");
     expect(context.timeline[0].updatedAt).toBeUndefined();
@@ -188,6 +185,17 @@ describe("GitHub pull request feedback context", () => {
     );
   });
 });
+
+/** @param {MockGitHubClient} client */
+function buildPullRequestContext(client) {
+  return buildIssueContext({
+    client,
+    issueNumber: "4",
+    repository: "example/repo",
+    token: "token",
+    type: "pull-request",
+  });
+}
 
 function pullRequestContextClient() {
   return mockGitHubClient({
@@ -352,6 +360,7 @@ function reviewThreadFixture() {
         },
       ],
     },
+    id: "thread-9",
     isOutdated: false,
     isResolved: false,
     path: "src/file.ts",
@@ -401,6 +410,7 @@ function filteredReviewThreadFixture(options) {
         },
       ],
     },
+    id: `thread-${options.id}`,
     isOutdated: options.isOutdated || false,
     isResolved: options.isResolved || false,
     path: "src/old.ts",
@@ -669,12 +679,7 @@ describe("GitVibe config and labels", () => {
   });
 });
 
-/**
- * @param {number} status
- * @param {unknown} value
- * @param {boolean} [ok]
- * @returns {any}
- */
+/** @param {number} status @param {unknown} value @param {boolean} [ok] */
 function response(status, value, ok = status >= 200 && status < 300) {
   return {
     ok,
@@ -683,10 +688,6 @@ function response(status, value, ok = status >= 200 && status < 300) {
   };
 }
 
-/**
- * @param {Partial<MockGitHubClient>} [overrides]
- * @returns {MockGitHubClient}
- */
 function mockGitHubClient(overrides = {}) {
   return /** @type {MockGitHubClient} */ ({
     apiBaseUrl: "https://api.github.test",

--- a/tests/context-github.test.mjs
+++ b/tests/context-github.test.mjs
@@ -50,11 +50,8 @@ describe("GitHub context builders", () => {
       "Path: src/file.ts\nDiff:\n@@ -1 +1 @@\n\nReview feedback",
       "Path: src/old.ts\nOutdated feedback",
     ]);
-    expect(context.timeline.at(-1)).toMatchObject({
-      reviewThreadId: "thread-11",
-      reviewThreadIsOutdated: true,
-    });
     expect(context.timeline.at(-2)).toMatchObject({
+      databaseId: 9,
       parentId: "8",
       reviewThreadId: "thread-9",
     });
@@ -352,6 +349,7 @@ function reviewThreadFixture() {
           authorAssociation: "COLLABORATOR",
           body: "Review feedback",
           createdAt: "2026-01-05T00:00:00Z",
+          databaseId: 9,
           diffHunk: "@@ -1 +1 @@",
           id: "9",
           replyTo: { id: "8" },
@@ -405,6 +403,7 @@ function filteredReviewThreadFixture(options) {
           author: { login: "reviewer" },
           body: options.body,
           createdAt: options.createdAt,
+          databaseId: Number(options.id),
           id: options.id,
           url: options.url,
         },

--- a/tests/context-pagination.test.mjs
+++ b/tests/context-pagination.test.mjs
@@ -55,7 +55,7 @@ describe("pull request review thread pagination", () => {
                       pageInfo: { hasNextPage: true, endCursor: "comment-cursor" },
                     },
                     id: "thread-1",
-                    isOutdated: false,
+                    isOutdated: true,
                     isResolved: false,
                     path: "src/a.ts",
                   },
@@ -102,9 +102,27 @@ describe("pull request review thread pagination", () => {
         token: "token",
       }),
     ).resolves.toMatchObject([
-      { body: "First", id: "comment-1", path: "src/a.ts" },
-      { body: "Second", id: "comment-2", path: "src/b.ts" },
-      { body: "Third", id: "comment-3", path: "src/c.ts" },
+      {
+        body: "First",
+        id: "comment-1",
+        path: "src/a.ts",
+        reviewThreadId: "thread-1",
+        reviewThreadIsOutdated: true,
+      },
+      {
+        body: "Second",
+        id: "comment-2",
+        path: "src/b.ts",
+        reviewThreadId: "thread-1",
+        reviewThreadIsOutdated: true,
+      },
+      {
+        body: "Third",
+        id: "comment-3",
+        path: "src/c.ts",
+        reviewThreadId: "thread-2",
+        reviewThreadIsOutdated: false,
+      },
     ]);
   });
 });

--- a/tests/context-pagination.test.mjs
+++ b/tests/context-pagination.test.mjs
@@ -51,7 +51,7 @@ describe("pull request review thread pagination", () => {
                 nodes: [
                   {
                     comments: {
-                      nodes: [{ body: "First", id: "comment-1" }],
+                      nodes: [{ body: "First", databaseId: 1, id: "comment-1" }],
                       pageInfo: { hasNextPage: true, endCursor: "comment-cursor" },
                     },
                     id: "thread-1",
@@ -68,7 +68,7 @@ describe("pull request review thread pagination", () => {
         .mockResolvedValueOnce({
           node: {
             comments: {
-              nodes: [{ body: "Second", id: "comment-2", path: "src/b.ts" }],
+              nodes: [{ body: "Second", databaseId: 2, id: "comment-2", path: "src/b.ts" }],
               pageInfo: { hasNextPage: false, endCursor: null },
             },
           },
@@ -79,7 +79,7 @@ describe("pull request review thread pagination", () => {
               reviewThreads: {
                 nodes: [
                   {
-                    comments: { nodes: [{ body: "Third", id: "comment-3" }] },
+                    comments: { nodes: [{ body: "Third", databaseId: 3, id: "comment-3" }] },
                     id: "thread-2",
                     isOutdated: false,
                     isResolved: false,
@@ -104,6 +104,7 @@ describe("pull request review thread pagination", () => {
     ).resolves.toMatchObject([
       {
         body: "First",
+        databaseId: 1,
         id: "comment-1",
         path: "src/a.ts",
         reviewThreadId: "thread-1",
@@ -111,6 +112,7 @@ describe("pull request review thread pagination", () => {
       },
       {
         body: "Second",
+        databaseId: 2,
         id: "comment-2",
         path: "src/b.ts",
         reviewThreadId: "thread-1",
@@ -118,6 +120,7 @@ describe("pull request review thread pagination", () => {
       },
       {
         body: "Third",
+        databaseId: 3,
         id: "comment-3",
         path: "src/c.ts",
         reviewThreadId: "thread-2",

--- a/tests/pr-review-publishing-reconciliation.test.mjs
+++ b/tests/pr-review-publishing-reconciliation.test.mjs
@@ -88,6 +88,32 @@ describe("pull request review publishing thread reconciliation", () => {
   });
 });
 
+describe("pull request review publishing blocked outputs", () => {
+  it("does not mark prior findings outdated when review output is blocked", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()]),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        next_state: "blocked",
+        stage: "review-matrix",
+        status: "blocked",
+        summary: "Review could not complete.",
+      },
+      runner: runner(),
+    });
+
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/comments/123/replies",
+    );
+    expect(reviewRequest(client).body.body).toContain("**Status:** `blocked`");
+    expect(client.graphql).not.toHaveBeenCalled();
+  });
+});
+
 describe("pull request review publishing reconciliation edge cases", () => {
   it("does not duplicate an existing finding update reply for the same commit", async () => {
     const client = createClient();

--- a/tests/pr-review-publishing-reconciliation.test.mjs
+++ b/tests/pr-review-publishing-reconciliation.test.mjs
@@ -124,6 +124,36 @@ describe("pull request review publishing reconciliation edge cases", () => {
     });
   });
 
+  it("ignores duplicate update markers from non-GitVibe authors", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding(), priorFindingUpdateReply({ author: "maintainer" })]),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        findings: ["src/app.ts:42 still misses pull_request.labeled."],
+        inline_comments: [
+          {
+            body: "This still misses `pull_request.labeled` handling.",
+            finding_id: "review-1",
+            line: 42,
+            path: "src/app.ts",
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+    });
+
+    const reply = requestCalls(client).find((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    expect(reply.body.body).toContain("This issue still exists after commit `abcdef123456`.");
+  });
+
   it("uses latest reviewed commit wording when the PR head SHA is unavailable", async () => {
     const client = createClient();
 
@@ -185,7 +215,7 @@ function priorReviewFinding(overrides = {}) {
   };
 }
 
-function priorFindingUpdateReply() {
+function priorFindingUpdateReply(overrides = {}) {
   return {
     author: "git-vibe",
     body: "<!-- git-vibe:review-finding-update id=review-1 status=still-present sha=abcdef123456 -->\nAlready noted.",
@@ -197,6 +227,7 @@ function priorFindingUpdateReply() {
     reviewThreadId: "thread-1",
     reviewThreadIsOutdated: false,
     url: "https://github.com/example/repo/pull/12#discussion_r124",
+    ...overrides,
   };
 }
 

--- a/tests/pr-review-publishing-reconciliation.test.mjs
+++ b/tests/pr-review-publishing-reconciliation.test.mjs
@@ -1,0 +1,249 @@
+// @ts-nocheck
+import { describe, expect, it, vi } from "vitest";
+import { publishStageResultComment } from "../src/runner/stage-publishing.ts";
+
+describe("pull request review publishing thread reconciliation", () => {
+  it("replies to an existing GitVibe thread when the same finding still exists", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()]),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        findings: ["src/app.ts:42 still misses pull_request.labeled."],
+        inline_comments: [
+          {
+            body: "This still misses `pull_request.labeled` handling.",
+            finding_id: "review-1",
+            line: 42,
+            path: "src/app.ts",
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+    });
+
+    const reply = requestCalls(client).find((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    expect(reply.body.body).toContain(
+      "<!-- git-vibe:review-finding-update id=review-1 status=still-present sha=abcdef123456 -->",
+    );
+    expect(reply.body.body).toContain("This issue still exists after commit `abcdef123456`.");
+    expect(reply.body.body).toContain("This still misses `pull_request.labeled` handling.");
+    expect(reviewRequest(client).body.comments).toBeUndefined();
+    expect(client.graphql).not.toHaveBeenCalled();
+  });
+
+  it("replies that a prior GitVibe thread is outdated before resolving it", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()]),
+      logger: createLogger(),
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    const replyIndex = requestCalls(client).findIndex((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    const reply = requestCalls(client)[replyIndex];
+    expect(reply.body.body).toContain(
+      "<!-- git-vibe:review-finding-update id=review-1 status=outdated sha=abcdef123456 -->",
+    );
+    expect(reply.body.body).toContain(
+      "This GitVibe finding is outdated after commit `abcdef123456`",
+    );
+    expect(client.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("resolveReviewThread"),
+      { threadId: "thread-1" },
+      "token",
+    );
+    expect(client.request.mock.invocationCallOrder[replyIndex]).toBeLessThan(
+      client.graphql.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not reconcile review threads authored by someone else", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding({ author: "maintainer" })]),
+      logger: createLogger(),
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/comments/123/replies",
+    );
+    expect(client.graphql).not.toHaveBeenCalled();
+  });
+});
+
+describe("pull request review publishing reconciliation edge cases", () => {
+  it("does not duplicate an existing finding update reply for the same commit", async () => {
+    const client = createClient();
+    const logger = createLogger();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding(), priorFindingUpdateReply()]),
+      logger,
+      parsedOutput: {
+        ...output(),
+        findings: ["src/app.ts:42 still misses pull_request.labeled."],
+        inline_comments: [
+          {
+            body: "This still misses `pull_request.labeled` handling.",
+            finding_id: "review-1",
+            line: 42,
+            path: "src/app.ts",
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+    });
+
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/comments/123/replies",
+    );
+    expect(logger.event).toHaveBeenCalledWith("github.pr.review_thread.reply.skip", {
+      finding: "review-1",
+      reason: "duplicate-update",
+      status: "still-present",
+    });
+  });
+
+  it("uses latest reviewed commit wording when the PR head SHA is unavailable", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()], { pullRequestHead: undefined }),
+      logger: createLogger(),
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    const reply = requestCalls(client).find((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    expect(reply.body.body).toContain(
+      "<!-- git-vibe:review-finding-update id=review-1 status=outdated sha=latest -->",
+    );
+    expect(reply.body.body).toContain(
+      "This GitVibe finding is outdated after the latest reviewed commit",
+    );
+  });
+});
+
+function context(timeline = [], overrides = {}) {
+  return {
+    artifact: {
+      body: "Body",
+      number: "12",
+      pullRequestHead:
+        "pullRequestHead" in overrides
+          ? overrides.pullRequestHead
+          : {
+              branch: "feature",
+              repository: "example/repo",
+              sha: "abcdef1234567890abcdef1234567890abcdef12",
+            },
+      title: "Title",
+      type: "pull-request",
+      url: "https://github.com/example/repo/pull/12",
+    },
+    generatedAt: "2026-01-01T00:00:00Z",
+    repository: "example/repo",
+    timeline,
+  };
+}
+
+function priorReviewFinding(overrides = {}) {
+  return {
+    author: "git-vibe",
+    body: "<!-- git-vibe:review-finding id=review-1 -->\nOriginal GitVibe finding.",
+    createdAt: "2026-01-01T00:00:00Z",
+    databaseId: 123,
+    id: "review-comment-node",
+    kind: "pull-request-review-comment",
+    reviewThreadId: "thread-1",
+    reviewThreadIsOutdated: false,
+    url: "https://github.com/example/repo/pull/12#discussion_r123",
+    ...overrides,
+  };
+}
+
+function priorFindingUpdateReply() {
+  return {
+    author: "git-vibe",
+    body: "<!-- git-vibe:review-finding-update id=review-1 status=still-present sha=abcdef123456 -->\nAlready noted.",
+    createdAt: "2026-01-01T00:01:00Z",
+    databaseId: 124,
+    id: "review-reply-node",
+    kind: "pull-request-review-comment",
+    parentId: "review-comment-node",
+    reviewThreadId: "thread-1",
+    reviewThreadIsOutdated: false,
+    url: "https://github.com/example/repo/pull/12#discussion_r124",
+  };
+}
+
+function output() {
+  return {
+    assumptions: [],
+    comment_body: "Result body.",
+    findings: [],
+    next_state: "ready-for-materialization",
+    references: [],
+    stage: "materialize",
+    status: "completed",
+    summary: "Result summary.",
+  };
+}
+
+function runner() {
+  return {
+    cwd: "/repo",
+    dryRun: false,
+    issueNumber: "12",
+    maxTurns: 2,
+    prNumber: "12",
+    repository: "example/repo",
+    stage: "review-matrix",
+    stageTimeoutMinutes: 1,
+    token: "token",
+  };
+}
+
+function createClient() {
+  return {
+    apiBaseUrl: "https://api.github.test",
+    graphql: vi.fn(async () => ({})),
+    request: vi.fn(async (request) => (request.path === "/user" ? { login: "git-vibe" } : {})),
+    retryBaseDelayMs: 0,
+  };
+}
+
+function createLogger() {
+  return { event: vi.fn() };
+}
+
+function requestCalls(client) {
+  return client.request.mock.calls.map((call) => call[0]);
+}
+
+function reviewRequest(client) {
+  return requestCalls(client).find((request) => request.path.endsWith("/pulls/12/reviews"));
+}

--- a/tests/pr-review-publishing.test.mjs
+++ b/tests/pr-review-publishing.test.mjs
@@ -58,7 +58,7 @@ describe("pull request review publishing", () => {
             side: "RIGHT",
           },
           {
-            body: "The range should share the same right-side anchor.",
+            body: expect.stringContaining("The range should share the same right-side anchor."),
             line: 48,
             path: "src/app.ts",
             side: "RIGHT",
@@ -349,7 +349,7 @@ describe("pull request review publishing rerun inline comment guards", () => {
         body: expect.objectContaining({
           comments: [
             {
-              body: "New line-specific feedback.",
+              body: expect.stringContaining("New line-specific feedback."),
               line: 42,
               path: "src/app.ts",
               side: "RIGHT",
@@ -460,20 +460,22 @@ describe("pull request review publishing validation", () => {
 
 /**
  * @param {ContextPacket["artifact"]["type"]} type
+ * @param {Partial<ContextPacket> & { pullRequestHead?: ContextPacket["artifact"]["pullRequestHead"] }} [overrides]
  * @returns {ContextPacket}
  */
-function context(type) {
+function context(type, overrides = {}) {
   return {
     artifact: {
       body: "Body",
       number: "12",
+      pullRequestHead: overrides.pullRequestHead,
       title: "Title",
       type,
       url: `https://github.com/example/repo/${type}s/12`,
     },
     generatedAt: "2026-01-01T00:00:00Z",
     repository: "example/repo",
-    timeline: [],
+    timeline: overrides.timeline || [],
   };
 }
 

--- a/tests/review-matrix-contract.test.mjs
+++ b/tests/review-matrix-contract.test.mjs
@@ -12,6 +12,7 @@ describe("review-matrix contract", () => {
       inline_comments: [
         {
           body: "Handle `pull_request.labeled` here so adding `git-vibe:review` to a PR starts review.",
+          finding_id: "review-1",
           line: 42,
           path: "src/app.ts",
           severity: "high",

--- a/tests/stage-contracts.test.mjs
+++ b/tests/stage-contracts.test.mjs
@@ -228,6 +228,7 @@ describe("stage prompt standards guidance", () => {
     expect(prompts.system).toContain("pull request or merge-preparation change");
     expect(prompts.prompt).toContain("PR can proceed to approval");
     expect(prompts.prompt).toContain("inline_comments");
+    expect(prompts.prompt).toContain("finding_id");
     expect(properties.inline_comments).toMatchObject({ type: "array" });
     expect(prompts.prompt).not.toContain("before PR creation");
   });


### PR DESCRIPTION
## Summary

- Add stable GitVibe review-finding markers and optional `finding_id` support for review-matrix inline comments.
- Reconcile app-owned prior PR review threads by replying when a finding still exists, replying with an outdated note before resolving when it no longer applies, and creating new inline comments only for new findings.
- Carry PR review thread metadata through context packing and add focused tests for reconciliation behavior.

## Validation

- `corepack pnpm check`
- Pre-commit hook ran `workflow-template-contract`, `coverage`, and `typecheck` during commit.

## Notes

The PR targets `dev` as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline review comments can reuse stable finding IDs so related comments are linked; timeline items and review comments now surface review-thread linkage and outdated status. Reconciliation updates prior threads (reply/resolve) when findings change.

* **Schema Updates**
  * Added and validated finding_id for inline comments.

* **Tests**
  * New/updated tests for thread reconciliation, outdated handling, duplicate-update prevention, and finding_id usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->