### PR TITLE
[codex] Trust GitVibe app bot for accepted risk

### DIFF
--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -36,7 +36,7 @@ interface StageResult {
   time: number;
 }
 
-const trustedAutomationAuthors = new Set(["github-actions[bot]"]);
+const trustedAutomationAuthors = new Set(["gitvibe-for-github[bot]"]);
 
 interface PullRequestReviewResponse {
   author_association?: string;

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -426,9 +426,9 @@ async function handleIssueLabeled(options: WebhookContext): Promise<void> {
 
   const issueNumber = String(options.payload.issue?.number || "");
   const runtimeLabel = isGitVibeRuntimeLabel(label);
-  const githubActionsActor = options.payload.sender?.login === "github-actions[bot]";
+  const gitVibeAppActor = options.payload.sender?.login === gitVibeAppBotLogin;
 
-  if (!(runtimeLabel && githubActionsActor) && !(await isTrustedActor(options))) {
+  if (!(runtimeLabel && gitVibeAppActor) && !(await isTrustedActor(options))) {
     await removeIssueLabel({
       client: options.client,
       issueNumber,
@@ -537,9 +537,9 @@ async function handleDiscussionLabeled(options: WebhookContext): Promise<void> {
 
   const discussionNumber = String(options.payload.discussion?.number || "");
   const runtimeLabel = isGitVibeRuntimeLabel(label);
-  const githubActionsActor = options.payload.sender?.login === "github-actions[bot]";
+  const gitVibeAppActor = options.payload.sender?.login === gitVibeAppBotLogin;
 
-  if (!(runtimeLabel && githubActionsActor) && !(await isTrustedActor(options))) {
+  if (!(runtimeLabel && gitVibeAppActor) && !(await isTrustedActor(options))) {
     await removeDiscussionLabelFromPayload(options, label);
     await createDiscussionComment(options, protectedLabelRejectionBody(options, label));
     return;
@@ -687,6 +687,7 @@ async function isTrustedActor(options: WebhookContext): Promise<boolean> {
   );
 }
 
+const gitVibeAppBotLogin = "gitvibe-for-github[bot]";
 const trustedPermissions = new Set(["admin", "maintain", "write"]);
 
 function summarizeError(error: unknown): string {

--- a/src/runner/accepted-risk.ts
+++ b/src/runner/accepted-risk.ts
@@ -19,7 +19,7 @@ import type {
 import { acceptedRiskDeltaContentUnits, type ContentUnit } from "./content-units.js";
 import type { StageLogger } from "./logging.js";
 
-const trustedAutomationAuthors = new Set(["github-actions[bot]"]);
+const trustedAutomationAuthors = new Set(["gitvibe-for-github[bot]"]);
 
 interface AcceptedRiskMetadataCandidate {
   metadata: AcceptedRiskMetadata;

--- a/tests/accepted-risk-run-binding.test.mjs
+++ b/tests/accepted-risk-run-binding.test.mjs
@@ -184,7 +184,7 @@ function acceptedRiskMetadata(overrides = {}) {
 }
 
 function blockedResultComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   markerArtifact = "issue",
   markerNumber = "12",

--- a/tests/accepted-risk-source-binding.test.mjs
+++ b/tests/accepted-risk-source-binding.test.mjs
@@ -123,7 +123,7 @@ function contextPacket({ artifact = "pull-request" } = {}) {
 }
 
 function timelineComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   body,
   createdAt = "2026-01-04T00:00:00Z",

--- a/tests/accepted-risk-stage-runner.test.mjs
+++ b/tests/accepted-risk-stage-runner.test.mjs
@@ -180,7 +180,7 @@ function acceptedRiskMetadataComment({ body, title = "Issue title" }) {
     html_url: "https://github.com/example/repo/issues/12#issuecomment-3",
     id: 3,
     updated_at: "2026-01-04T00:00:00Z",
-    user: { login: "github-actions[bot]" },
+    user: { login: "gitvibe-for-github[bot]" },
   };
 }
 

--- a/tests/accepted-risk.test.mjs
+++ b/tests/accepted-risk.test.mjs
@@ -252,7 +252,7 @@ describe("accepted-risk context marker rejection", () => {
 });
 
 describe("accepted-risk context trusted automation", () => {
-  it("trusts GitHub Actions metadata when author association is absent", () => {
+  it("trusts GitVibe App metadata when author association is absent", () => {
     expect(
       acceptedRiskFromContext({
         context: issueContext({
@@ -581,7 +581,7 @@ function acceptedRiskMetadata(overrides = {}) {
 }
 
 function blockedResultComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   markerArtifact = "issue",
   markerNumber = "12",
@@ -609,7 +609,7 @@ function blockedResultComment({
 
 function issueTimelineComment(body) {
   return {
-    author: "github-actions[bot]",
+    author: "gitvibe-for-github[bot]",
     authorAssociation: "NONE",
     body,
     createdAt: "2026-01-04T00:01:00Z",
@@ -620,7 +620,7 @@ function issueTimelineComment(body) {
 }
 
 function riskAcceptedAuditComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   run,
   stage,

--- a/tests/content-units.test.mjs
+++ b/tests/content-units.test.mjs
@@ -194,7 +194,7 @@ describe("accepted-risk metadata context unit filtering", () => {
     };
     context.timeline = [
       {
-        author: "github-actions[bot]",
+        author: "gitvibe-for-github[bot]",
         body: resultBody,
         createdAt: "2026-01-04T00:00:00Z",
         id: "100",

--- a/tests/safety-gate-runner.test.mjs
+++ b/tests/safety-gate-runner.test.mjs
@@ -634,7 +634,7 @@ function acceptedRiskMetadataComment({ body, title = "Issue title" }) {
       "2026-01-04T00:00:00Z",
     ),
     author_association: "OWNER",
-    user: { login: "github-actions[bot]" },
+    user: { login: "gitvibe-for-github[bot]" },
   };
 }
 

--- a/tests/server-accept-risk-labels.test.mjs
+++ b/tests/server-accept-risk-labels.test.mjs
@@ -177,9 +177,11 @@ describe("GitVibe app server accept-risk pull request reviews", () => {
       pullRequestReviews: [
         stageResultReview({
           artifact: "pull-request",
+          authorAssociation: "NONE",
           number: 12,
           stage: "review-matrix",
           submittedAt: "2026-01-02T00:00:00Z",
+          user: "gitvibe-for-github[bot]",
         }),
       ],
     });
@@ -287,7 +289,7 @@ describe("GitVibe app server accept-risk label result selection", () => {
             submittedAt: "2026-01-03T00:00:00Z",
           }),
           author_association: "NONE",
-          user: { login: "github-actions[bot]" },
+          user: { login: "gitvibe-for-github[bot]" },
         },
         stageResultComment({
           artifact: "issue",
@@ -650,13 +652,20 @@ function stageResultComment({
   };
 }
 
-function stageResultReview({ artifact, number, stage, submittedAt = "2026-01-01T00:00:00Z" }) {
+function stageResultReview({
+  artifact,
+  authorAssociation = "OWNER",
+  number,
+  stage,
+  submittedAt = "2026-01-01T00:00:00Z",
+  user = "maintainer",
+}) {
   return {
-    author_association: "OWNER",
+    author_association: authorAssociation,
     body: stageResultBody({ artifact, number, stage }),
     id: 200,
     submitted_at: submittedAt,
-    user: { login: "maintainer" },
+    user: { login: user },
   };
 }
 

--- a/tests/server-runtime-labels.test.mjs
+++ b/tests/server-runtime-labels.test.mjs
@@ -13,14 +13,14 @@ import {
 } from "./support/server-app.mjs";
 
 describe("GitVibe app server managed runtime labels", () => {
-  it("accepts managed runtime issue labels from GitHub Actions", async () => {
+  it("accepts managed runtime issue labels from the GitVibe App bot", async () => {
     const client = createClient({ permission: new Error("GitHub API GET permission failed: 404") });
     await createApp({ client }).handleWebhook("issues", {
       action: "labeled",
       issue: { number: 11 },
       label: { name: gitVibeLabels.blocked.name },
       repository: repositoryPayload(),
-      sender: { login: "github-actions[bot]" },
+      sender: { login: "gitvibe-for-github[bot]" },
     });
 
     expect(workflowDispatches(client)).toEqual([]);
@@ -47,7 +47,7 @@ describe("GitVibe app server managed runtime labels", () => {
     );
   });
 
-  it("accepts managed runtime discussion labels from GitHub Actions", async () => {
+  it("accepts managed runtime discussion labels from the GitVibe App bot", async () => {
     const client = createClient({ permission: new Error("GitHub API GET permission failed: 404") });
     const app = createApp({ client });
 
@@ -56,7 +56,7 @@ describe("GitVibe app server managed runtime labels", () => {
       discussion: { node_id: "discussion-node", number: 5 },
       label: { name: gitVibeLabels.blocked.name, node_id: "blocked-label-node" },
       repository: repositoryPayload(),
-      sender: { login: "github-actions[bot]" },
+      sender: { login: "gitvibe-for-github[bot]" },
     });
 
     expect(workflowDispatches(client)).toEqual([]);
@@ -85,14 +85,14 @@ describe("GitVibe app server managed runtime labels", () => {
     );
   });
 
-  it("ignores managed runtime pull request label events from GitHub Actions", async () => {
+  it("ignores managed runtime pull request label events from the GitVibe App bot", async () => {
     const client = createClient({ permission: new Error("GitHub API GET permission failed: 404") });
     await createApp({ client }).handleWebhook("pull_request", {
       action: "labeled",
       label: { name: gitVibeLabels.blocked.name },
       pull_request: { number: 12 },
       repository: repositoryPayload(),
-      sender: { login: "github-actions[bot]" },
+      sender: { login: "gitvibe-for-github[bot]" },
     });
 
     expect(workflowDispatches(client)).toEqual([]);

--- a/tests/stage-runner-matrix.test.mjs
+++ b/tests/stage-runner-matrix.test.mjs
@@ -692,6 +692,6 @@ function blockedResultComment({
     node_id: "review-100",
     submitted_at: "2026-01-02T00:00:00Z",
     updated_at: "2026-01-04T00:00:00Z",
-    user: { login: "github-actions[bot]" },
+    user: { login: "gitvibe-for-github[bot]" },
   };
 }


### PR DESCRIPTION
## Summary

Trust the official `gitvibe-for-github[bot]` identity for accepted-risk stage result and metadata lookup, and remove `github-actions[bot]` from those accept-risk trust lists.

## Why

GitVibe stage results authored by the GitHub App appear with `author_association: NONE`. The accept-risk label handler and rerun metadata reader were still trusting `github-actions[bot]`, so valid blocked GitVibe App reviews could be ignored and the label could be removed with a misleading no-op message.

## Validation

- `corepack pnpm vitest run tests/server-accept-risk-labels.test.mjs tests/accepted-risk.test.mjs tests/accepted-risk-run-binding.test.mjs tests/accepted-risk-source-binding.test.mjs tests/content-units.test.mjs tests/stage-runner-matrix.test.mjs tests/accepted-risk-stage-runner.test.mjs tests/safety-gate-runner.test.mjs`
- `corepack pnpm check`

The pre-commit hook also ran lint-staged, workflow template contract checks, typecheck, and coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Trusted automation identity updated: the app now recognizes gitvibe-for-github[bot] (instead of the previous bot) as an authorized source for accepted-risk comments and timeline items.
  * Managed runtime label handling now accepts labels/comments from the GitVibe app bot as valid triggers for label-based actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->