### PR TITLE
[codex] Promote dev to main for v4.0.2

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,3 +6,5 @@ reviews:
     base_branches:
       - "^main$"
       - "^dev$"
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Discussions: Read and write
 Issues: Read and write
 Pull requests: Read and write
 Secrets: Read and write
+Variables: Read-only
 Workflows: Read and write
 ```
 

--- a/prompts/review-matrix/user.md
+++ b/prompts/review-matrix/user.md
@@ -18,6 +18,7 @@ Review the proposed pull request or merge-preparation change. Report only valida
 - Do not report preferences, speculative improvements, over-engineering requests, or broad refactors as blockers.
 - If required fixes exist, keep `status` as `completed`, set `next_state` to `changes-required`, and put only actionable required fixes in `findings`.
 - For each required fix that can be anchored to an exact changed pull request diff line, add a matching `inline_comments` item with `path`, right-side `line`, and a concise `body` that explains the failure and required fix. Use `start_line` only for a contiguous range on the same side. Do not invent anchors; keep unanchored blockers in `findings` and `comment_body`.
+- If an existing GitVibe inline review comment contains a hidden `git-vibe:review-finding id=...` marker and the same issue still applies, set the new `inline_comments` item `finding_id` to that id. Do not copy hidden markers into `body`.
 - If no required fix exists, say so in `summary`, keep `findings` empty, and set `next_state` to `review-passed`.
 - Use `blocked` only when the review itself cannot be completed or a maintainer decision is required before code can continue.
   </finding_standard>
@@ -26,7 +27,7 @@ Review the proposed pull request or merge-preparation change. Report only valida
 
 - `tests`: Review-relevant checks observed or recommended.
 - `findings`: Blocking issues only, ordered by severity.
-- `inline_comments`: GitHub PR review comments for blocking findings that have exact changed-line anchors. Leave empty or omit when there are no anchorable blockers.
+- `inline_comments`: GitHub PR review comments for blocking findings that have exact changed-line anchors. Reuse `finding_id` from an existing GitVibe marker when reporting the same issue again. Leave empty or omit when there are no anchorable blockers.
 - `questions`: Maintainer decisions required before code can continue, preferably as answerable question objects with up to four options.
 - `next_state`: Use `review-passed` when the PR can proceed to approval, `changes-required` when implementation must address evidence-backed findings before the PR is ready for approval, or `blocked` when automation must stop.
   </required_fields_guidance>

--- a/schemas/stages/review-matrix.v1.schema.json
+++ b/schemas/stages/review-matrix.v1.schema.json
@@ -31,6 +31,10 @@
           "line": { "type": "integer", "minimum": 1 },
           "start_line": { "type": "integer", "minimum": 1 },
           "side": { "type": "string", "enum": ["LEFT", "RIGHT"] },
+          "finding_id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$"
+          },
           "body": { "type": "string", "minLength": 1 },
           "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] }
         }

--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -36,7 +36,7 @@ interface StageResult {
   time: number;
 }
 
-const trustedAutomationAuthors = new Set(["github-actions[bot]"]);
+const trustedAutomationAuthors = new Set(["gitvibe-for-github[bot]"]);
 
 interface PullRequestReviewResponse {
   author_association?: string;

--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -14,9 +14,11 @@ import {
   stageResultStatus,
   type StageResultMarker,
 } from "../shared/stage-result-markers.js";
+import { gitVibeInternalLabels, gitVibeLabels } from "../shared/labels.js";
 import { workflowRunIdFromUrl } from "../shared/status-comments.js";
 import type { Stage } from "../shared/types.js";
 import {
+  addIssueLabel,
   createDiscussionComment,
   createIssueComment,
   dispatchWorkflow,
@@ -24,6 +26,7 @@ import {
   postQueuedWorkflowComment,
   repositoryWorkflowBudgetInputs,
   removeDiscussionLabelFromPayload,
+  removeIssueLabelIfPresent,
   type WebhookActionContext,
 } from "./server-actions.js";
 import { removeIssueLabel } from "./labels.js";
@@ -132,6 +135,7 @@ export async function handleAcceptRiskLabel(
   const stored = await storeRunBoundAcceptedRisk(options, label, result, plan, boundAcceptance);
   if (!stored) return;
 
+  await markAcceptedRiskWorkflowRunning(options, plan);
   await removeAcceptRiskLabel(options, label);
   await postQueuedWorkflowComment(options, {
     artifact: plan.artifact,
@@ -183,6 +187,19 @@ async function storeRunBoundAcceptedRisk(
     );
     return false;
   }
+}
+
+async function markAcceptedRiskWorkflowRunning(
+  options: WebhookActionContext,
+  plan: ResumePlan,
+): Promise<void> {
+  if (plan.artifact !== "pull-request" || plan.workflow !== "review.yml") return;
+
+  await removeIssueLabelIfPresent(options, plan.number, gitVibeLabels.readyForApproval.name);
+  await removeIssueLabelIfPresent(options, plan.number, gitVibeLabels.blocked.name);
+  await removeIssueLabelIfPresent(options, plan.number, gitVibeLabels.reviewing.name);
+  await removeIssueLabelIfPresent(options, plan.number, gitVibeInternalLabels.reviewFix.name);
+  await addIssueLabel(options, plan.number, gitVibeLabels.reviewing.name);
 }
 
 function workflowRunIdFromDispatch(dispatch: AcceptedRiskWorkflowDispatch): string {

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -426,9 +426,9 @@ async function handleIssueLabeled(options: WebhookContext): Promise<void> {
 
   const issueNumber = String(options.payload.issue?.number || "");
   const runtimeLabel = isGitVibeRuntimeLabel(label);
-  const githubActionsActor = options.payload.sender?.login === "github-actions[bot]";
+  const gitVibeAppActor = options.payload.sender?.login === gitVibeAppBotLogin;
 
-  if (!(runtimeLabel && githubActionsActor) && !(await isTrustedActor(options))) {
+  if (!(runtimeLabel && gitVibeAppActor) && !(await isTrustedActor(options))) {
     await removeIssueLabel({
       client: options.client,
       issueNumber,
@@ -537,9 +537,9 @@ async function handleDiscussionLabeled(options: WebhookContext): Promise<void> {
 
   const discussionNumber = String(options.payload.discussion?.number || "");
   const runtimeLabel = isGitVibeRuntimeLabel(label);
-  const githubActionsActor = options.payload.sender?.login === "github-actions[bot]";
+  const gitVibeAppActor = options.payload.sender?.login === gitVibeAppBotLogin;
 
-  if (!(runtimeLabel && githubActionsActor) && !(await isTrustedActor(options))) {
+  if (!(runtimeLabel && gitVibeAppActor) && !(await isTrustedActor(options))) {
     await removeDiscussionLabelFromPayload(options, label);
     await createDiscussionComment(options, protectedLabelRejectionBody(options, label));
     return;
@@ -687,6 +687,7 @@ async function isTrustedActor(options: WebhookContext): Promise<boolean> {
   );
 }
 
+const gitVibeAppBotLogin = "gitvibe-for-github[bot]";
 const trustedPermissions = new Set(["admin", "maintain", "write"]);
 
 function summarizeError(error: unknown): string {

--- a/src/runner/accepted-risk.ts
+++ b/src/runner/accepted-risk.ts
@@ -19,7 +19,7 @@ import type {
 import { acceptedRiskDeltaContentUnits, type ContentUnit } from "./content-units.js";
 import type { StageLogger } from "./logging.js";
 
-const trustedAutomationAuthors = new Set(["github-actions[bot]"]);
+const trustedAutomationAuthors = new Set(["gitvibe-for-github[bot]"]);
 
 interface AcceptedRiskMetadataCandidate {
   metadata: AcceptedRiskMetadata;

--- a/src/runner/content-units.ts
+++ b/src/runner/content-units.ts
@@ -480,6 +480,8 @@ function packedTimelineItem(item: TimelineItem, index: number): JsonObject {
     kind: item.kind,
     parentId: item.parentId,
     reactions: item.reactions,
+    reviewThreadId: item.reviewThreadId,
+    reviewThreadIsOutdated: item.reviewThreadIsOutdated,
     url: item.url,
   };
 }

--- a/src/runner/context-graphql.ts
+++ b/src/runner/context-graphql.ts
@@ -22,6 +22,8 @@ export interface PullRequestReviewCommentNode {
   id: string;
   path?: string;
   replyTo?: { id?: string } | null;
+  reviewThreadId?: string;
+  reviewThreadIsOutdated?: boolean;
   updatedAt?: string;
   url?: string;
 }
@@ -130,9 +132,14 @@ export async function openPullRequestReviewComments(options: {
     token: options.token,
   });
   return threads
-    .filter((thread) => !thread.isResolved && !thread.isOutdated)
+    .filter((thread) => !thread.isResolved)
     .flatMap((thread) =>
-      thread.comments.nodes.map((comment) => ({ ...comment, path: comment.path || thread.path })),
+      thread.comments.nodes.map((comment) => ({
+        ...comment,
+        path: comment.path || thread.path,
+        reviewThreadId: thread.id,
+        reviewThreadIsOutdated: thread.isOutdated,
+      })),
     );
 }
 
@@ -396,6 +403,7 @@ const pullRequestReviewThreadsQuery = `
               pageInfo { hasNextPage endCursor }
               nodes {
                 id
+                databaseId
                 body
                 createdAt
                 updatedAt
@@ -422,6 +430,7 @@ const pullRequestReviewThreadCommentsQuery = `
           pageInfo { hasNextPage endCursor }
           nodes {
             id
+            databaseId
             body
             createdAt
             updatedAt

--- a/src/runner/context.ts
+++ b/src/runner/context.ts
@@ -441,6 +441,8 @@ function toPullRequestReviewTimelineItem(item: PullRequestReviewCommentNode): Ti
     authorAssociation: item.authorAssociation,
     databaseId: item.databaseId,
     parentId: item.replyTo?.id ? String(item.replyTo.id) : undefined,
+    reviewThreadId: item.reviewThreadId,
+    reviewThreadIsOutdated: item.reviewThreadIsOutdated,
   };
 }
 

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { GitHubClient, splitRepository } from "../shared/github.js";
 import { workflowRunIdFromUrl } from "../shared/status-comments.js";
 import type { ContextPacket, JsonObject, RunnerOptions } from "../shared/types.js";
@@ -12,9 +13,29 @@ interface PullRequestReviewComment {
   start_side?: "LEFT" | "RIGHT";
 }
 
+interface ReviewFindingComment {
+  body: string;
+  findingId: string;
+  reviewComment: PullRequestReviewComment;
+}
+
+interface PriorReviewFinding {
+  commentDatabaseId: string;
+  findingId: string;
+  reviewThreadId: string;
+  updateKeys: Set<string>;
+}
+
 interface AuthenticatedUserResponse extends JsonObject {
   login?: string;
 }
+
+interface ReviewedCommit {
+  label: string;
+  markerSha: string;
+}
+
+type ReviewFindingUpdateStatus = "outdated" | "still-present";
 
 export async function publishPullRequestReviewResult(options: {
   client: GitHubClient;
@@ -26,7 +47,11 @@ export async function publishPullRequestReviewResult(options: {
 }): Promise<boolean> {
   if (!shouldPublishPullRequestReview(options)) return false;
 
-  const comments = inlineReviewComments(options.parsedOutput.inline_comments);
+  const findings = reviewFindingComments(options.parsedOutput.inline_comments);
+  const newFindings = shouldReconcileReviewFindings(options.parsedOutput)
+    ? (await reconcileReviewFindings({ ...options, findings })).newFindings
+    : findings;
+  const comments = newFindings.map((finding) => finding.reviewComment);
   const body = pullRequestReviewBody({
     comments,
     output: options.parsedOutput,
@@ -85,6 +110,14 @@ function shouldPublishPullRequestReview(options: {
   );
 }
 
+function shouldReconcileReviewFindings(output: JsonObject): boolean {
+  return (
+    String(output.status || "")
+      .trim()
+      .toLowerCase() === "completed"
+  );
+}
+
 async function editableReviewForStageResult(options: {
   client: GitHubClient;
   comments: PullRequestReviewComment[];
@@ -115,6 +148,7 @@ async function editableReviewForStageResult(options: {
 
   const login = await authenticatedGitHubLogin({
     client: options.client,
+    eventName: "github.pr.review.update.skip",
     logger: options.logger,
     token: options.runner.token,
   });
@@ -131,14 +165,7 @@ async function editableReviewForStageResult(options: {
 function parseStageResultMarker(
   body: string,
 ): { artifact: string; number: string; run?: string; stage: string } | undefined {
-  const match = body.match(/<!--\s*git-vibe:stage-result\s+([^>]*)-->/);
-  if (!match) return undefined;
-  const attributes = Object.fromEntries(
-    [...(match[1] || "").matchAll(/([a-z][a-z-]*)=([^\s>]+)/g)].map((entry) => [
-      entry[1],
-      entry[2],
-    ]),
-  );
+  const attributes = markerAttributes(body, "git-vibe:stage-result");
   if (!attributes.stage || !attributes.artifact || !attributes.number) return undefined;
   return {
     artifact: attributes.artifact,
@@ -170,6 +197,7 @@ function sameGitHubLogin(left: string, right: string): boolean {
 
 async function authenticatedGitHubLogin(options: {
   client: GitHubClient;
+  eventName: string;
   logger: StageLogger;
   token: string;
 }): Promise<string | undefined> {
@@ -181,14 +209,14 @@ async function authenticatedGitHubLogin(options: {
       token: options.token,
     });
   } catch {
-    options.logger.event("github.pr.review.update.skip", {
+    options.logger.event(options.eventName, {
       reason: "unknown-token-author",
     });
     return undefined;
   }
   const login = stringField(user.login);
   if (!login) {
-    options.logger.event("github.pr.review.update.skip", {
+    options.logger.event(options.eventName, {
       reason: "unknown-token-author",
     });
     return undefined;
@@ -234,27 +262,226 @@ async function updatePullRequestReview(options: {
   });
 }
 
-function inlineReviewComments(value: unknown): PullRequestReviewComment[] {
+async function reconcileReviewFindings(options: {
+  client: GitHubClient;
+  context: ContextPacket;
+  findings: ReviewFindingComment[];
+  logger: StageLogger;
+  runner: RunnerOptions;
+}): Promise<{ newFindings: ReviewFindingComment[] }> {
+  const priorFindings = await priorReviewFindings(options);
+  if (!priorFindings.size) return { newFindings: options.findings };
+
+  const commit = reviewedCommit(options.context);
+  const currentFindingIds = new Set(options.findings.map((finding) => finding.findingId));
+  const newFindings: ReviewFindingComment[] = [];
+
+  for (const finding of options.findings) {
+    const prior = priorFindings.get(finding.findingId);
+    if (!prior) {
+      newFindings.push(finding);
+      continue;
+    }
+    await replyToPriorReviewFinding({
+      ...options,
+      body: stillPresentReviewFindingReply(finding.body, commit.label),
+      commit,
+      prior,
+      status: "still-present",
+    });
+  }
+
+  for (const prior of priorFindings.values()) {
+    if (currentFindingIds.has(prior.findingId)) continue;
+    await replyToPriorReviewFinding({
+      ...options,
+      body: outdatedReviewFindingReply(commit.label),
+      commit,
+      prior,
+      status: "outdated",
+    });
+    await resolveReviewThread({
+      client: options.client,
+      logger: options.logger,
+      reviewThreadId: prior.reviewThreadId,
+      token: options.runner.token,
+    });
+  }
+
+  return { newFindings };
+}
+
+async function priorReviewFindings(options: {
+  client: GitHubClient;
+  context: ContextPacket;
+  logger: StageLogger;
+  runner: RunnerOptions;
+}): Promise<Map<string, PriorReviewFinding>> {
+  const candidates = priorReviewFindingCandidates(options.context);
+  if (!candidates.length) return new Map();
+
+  const login = await authenticatedGitHubLogin({
+    client: options.client,
+    eventName: "github.pr.review_thread.reconcile.skip",
+    logger: options.logger,
+    token: options.runner.token,
+  });
+  if (!login) return new Map();
+
+  const findings = new Map<string, PriorReviewFinding>();
+  const updates = reviewFindingUpdatesByThread(options.context, login);
+  for (const candidate of candidates) {
+    if (!sameGitHubLogin(candidate.author, login)) continue;
+    findings.set(candidate.findingId, {
+      ...candidate,
+      updateKeys: updates.get(candidate.reviewThreadId) || new Set(),
+    });
+  }
+  return findings;
+}
+
+function priorReviewFindingCandidates(
+  context: ContextPacket,
+): Array<Omit<PriorReviewFinding, "updateKeys"> & { author: string }> {
+  const candidates: Array<Omit<PriorReviewFinding, "updateKeys"> & { author: string }> = [];
+  for (const item of context.timeline) {
+    if (item.kind !== "pull-request-review-comment" || item.parentId) continue;
+    const findingId = parseReviewFindingMarker(item.body)?.id;
+    const reviewThreadId = stringField(item.reviewThreadId);
+    const commentDatabaseId = reviewCommentDatabaseId(item.databaseId);
+    if (!findingId || !reviewThreadId || !commentDatabaseId) continue;
+    candidates.push({
+      author: item.author,
+      commentDatabaseId,
+      findingId,
+      reviewThreadId,
+    });
+  }
+  return candidates;
+}
+
+function reviewFindingUpdatesByThread(
+  context: ContextPacket,
+  login: string,
+): Map<string, Set<string>> {
+  const updates = new Map<string, Set<string>>();
+  for (const item of context.timeline) {
+    if (item.kind !== "pull-request-review-comment" || !item.reviewThreadId) continue;
+    if (!sameGitHubLogin(item.author, login)) continue;
+    const marker = parseReviewFindingUpdateMarker(item.body);
+    if (!marker) continue;
+    const key = reviewFindingUpdateKey(marker);
+    const threadUpdates = updates.get(item.reviewThreadId) || new Set<string>();
+    threadUpdates.add(key);
+    updates.set(item.reviewThreadId, threadUpdates);
+  }
+  return updates;
+}
+
+async function replyToPriorReviewFinding(options: {
+  body: string;
+  client: GitHubClient;
+  commit: ReviewedCommit;
+  context: ContextPacket;
+  logger: StageLogger;
+  prior: PriorReviewFinding;
+  runner: RunnerOptions;
+  status: ReviewFindingUpdateStatus;
+}): Promise<void> {
+  const update = {
+    id: options.prior.findingId,
+    sha: options.commit.markerSha,
+    status: options.status,
+  };
+  const updateKey = reviewFindingUpdateKey(update);
+  if (options.prior.updateKeys.has(updateKey)) {
+    options.logger.event("github.pr.review_thread.reply.skip", {
+      finding: options.prior.findingId,
+      reason: "duplicate-update",
+      status: options.status,
+    });
+    return;
+  }
+
+  options.logger.event("github.pr.review_thread.reply.start", {
+    finding: options.prior.findingId,
+    pull_request: options.context.artifact.number,
+    status: options.status,
+  });
+  await createPullRequestReviewReply({
+    body: `${reviewFindingUpdateMarker(update)}\n${options.body}`,
+    client: options.client,
+    commentId: options.prior.commentDatabaseId,
+    pullNumber: options.context.artifact.number,
+    repository: options.runner.repository,
+    token: options.runner.token,
+  });
+  options.prior.updateKeys.add(updateKey);
+  options.logger.event("github.pr.review_thread.reply.done", {
+    finding: options.prior.findingId,
+    pull_request: options.context.artifact.number,
+    status: options.status,
+  });
+}
+
+async function createPullRequestReviewReply(options: {
+  body: string;
+  client: GitHubClient;
+  commentId: string;
+  pullNumber: string;
+  repository: string;
+  token: string;
+}): Promise<void> {
+  const { owner, repo } = splitRepository(options.repository);
+  await options.client.request({
+    body: { body: options.body },
+    method: "POST",
+    path: `/repos/${owner}/${repo}/pulls/${options.pullNumber}/comments/${options.commentId}/replies`,
+    token: options.token,
+  });
+}
+
+async function resolveReviewThread(options: {
+  client: GitHubClient;
+  logger: StageLogger;
+  reviewThreadId: string;
+  token: string;
+}): Promise<void> {
+  options.logger.event("github.pr.review_thread.resolve.start", {
+    thread: options.reviewThreadId,
+  });
+  await options.client.graphql(
+    resolveReviewThreadMutation,
+    { threadId: options.reviewThreadId },
+    options.token,
+  );
+  options.logger.event("github.pr.review_thread.resolve.done", {
+    thread: options.reviewThreadId,
+  });
+}
+
+function reviewFindingComments(value: unknown): ReviewFindingComment[] {
   if (value === undefined) return [];
   if (!Array.isArray(value)) {
     throw new Error("review-matrix inline_comments must be an array.");
   }
-  return value.map((item, index) => inlineReviewComment(item, index));
+  return value.map((item, index) => reviewFindingComment(item, index));
 }
 
-function inlineReviewComment(value: unknown, index: number): PullRequestReviewComment {
+function reviewFindingComment(value: unknown, index: number): ReviewFindingComment {
   if (!isRecord(value)) {
     throw new Error(`review-matrix inline_comments[${index}] must be an object.`);
   }
   const path = stringField(value.path);
-  const body = stringField(value.body);
+  const rawBody = stringField(value.body);
+  const body = visibleReviewCommentBody(rawBody);
   const line = integerField(value.line);
   if (!path || !body || line === undefined) {
     throw new Error(`review-matrix inline_comments[${index}] must define path, line, and body.`);
   }
 
   const side = sideField(value.side);
-  const comment: PullRequestReviewComment = { body, line, path, side };
+  const reviewComment: PullRequestReviewComment = { body, line, path, side };
   const startLine = integerField(value.start_line);
   if (startLine !== undefined) {
     if (startLine > line) {
@@ -262,10 +489,111 @@ function inlineReviewComment(value: unknown, index: number): PullRequestReviewCo
         `review-matrix inline_comments[${index}].start_line must be less than or equal to line.`,
       );
     }
-    comment.start_line = startLine;
-    comment.start_side = side;
+    reviewComment.start_line = startLine;
+    reviewComment.start_side = side;
   }
-  return comment;
+  const findingId =
+    normalizedFindingId(value.finding_id) ||
+    parseReviewFindingMarker(rawBody)?.id ||
+    generatedFindingId({ body, line, path, startLine });
+  reviewComment.body = `${reviewFindingMarker(findingId)}\n${body}`;
+  return { body, findingId, reviewComment };
+}
+
+function reviewFindingMarker(id: string): string {
+  return `<!-- git-vibe:review-finding id=${id} -->`;
+}
+
+function reviewFindingUpdateMarker(options: {
+  id: string;
+  sha: string;
+  status: ReviewFindingUpdateStatus;
+}): string {
+  return `<!-- git-vibe:review-finding-update id=${options.id} status=${options.status} sha=${options.sha} -->`;
+}
+
+function parseReviewFindingMarker(body: string): { id: string } | undefined {
+  const id = normalizedFindingId(markerAttributes(body, "git-vibe:review-finding").id);
+  return id ? { id } : undefined;
+}
+
+function parseReviewFindingUpdateMarker(
+  body: string,
+): { id: string; sha: string; status: ReviewFindingUpdateStatus } | undefined {
+  const attributes = markerAttributes(body, "git-vibe:review-finding-update");
+  const id = normalizedFindingId(attributes.id);
+  const sha = normalizedFindingMarkerValue(attributes.sha);
+  const status = reviewFindingUpdateStatus(attributes.status);
+  if (!id || !sha || !status) return undefined;
+  return { id, sha, status };
+}
+
+function markerAttributes(body: string, marker: string): Record<string, string> {
+  const match = body.match(new RegExp(`<!--\\s*${marker}\\s+([^>]*)-->`));
+  if (!match) return {};
+  return Object.fromEntries(
+    [...(match[1] || "").matchAll(/([a-z][a-z-]*)=([^\s>]+)/g)].map((entry) => [
+      entry[1],
+      entry[2],
+    ]),
+  );
+}
+
+function reviewFindingUpdateStatus(value: unknown): ReviewFindingUpdateStatus | undefined {
+  return value === "outdated" || value === "still-present" ? value : undefined;
+}
+
+function reviewFindingUpdateKey(options: {
+  id: string;
+  sha: string;
+  status: ReviewFindingUpdateStatus;
+}): string {
+  return `${options.id}:${options.status}:${options.sha}`;
+}
+
+function visibleReviewCommentBody(body: string): string {
+  return body.replace(/<!--\s*git-vibe:review-finding(?:-update)?\s+[^>]*-->\s*/g, "").trim();
+}
+
+function generatedFindingId(options: {
+  body: string;
+  line: number;
+  path: string;
+  startLine?: number;
+}): string {
+  const fingerprint = [options.path, options.startLine || "", options.line, options.body]
+    .map((part) => String(part).trim())
+    .join("\0");
+  return `gv-${createHash("sha256").update(fingerprint).digest("hex").slice(0, 16)}`;
+}
+
+function normalizedFindingId(value: unknown): string | undefined {
+  const id = stringField(value);
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/.test(id) ? id : undefined;
+}
+
+function normalizedFindingMarkerValue(value: unknown): string | undefined {
+  const markerValue = stringField(value);
+  return /^[A-Za-z0-9._:-]+$/.test(markerValue) ? markerValue : undefined;
+}
+
+function reviewCommentDatabaseId(value: number | string | undefined): string | undefined {
+  return reviewDatabaseId(value);
+}
+
+function reviewedCommit(context: ContextPacket): ReviewedCommit {
+  const sha = stringField(context.artifact.pullRequestHead?.sha);
+  if (!sha) return { label: "the latest reviewed commit", markerSha: "latest" };
+  const shortSha = sha.slice(0, 12);
+  return { label: `commit \`${shortSha}\``, markerSha: shortSha };
+}
+
+function stillPresentReviewFindingReply(body: string, commitLabel: string): string {
+  return cleanLines([`This issue still exists after ${commitLabel}.`, "", body]).join("\n");
+}
+
+function outdatedReviewFindingReply(commitLabel: string): string {
+  return `This GitVibe finding is outdated after ${commitLabel}; the latest review no longer reports this issue.`;
 }
 
 function pullRequestReviewBody(options: {
@@ -338,3 +666,13 @@ function cleanLines(lines: string[]): string[] {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+const resolveReviewThreadMutation = `
+  mutation GitVibeResolveReviewThread($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread {
+        id
+      }
+    }
+  }
+`;

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -456,7 +456,17 @@ function reviewFindingComments(value: unknown): ReviewFindingComment[] {
   if (!Array.isArray(value)) {
     throw new Error("review-matrix inline_comments must be an array.");
   }
-  return value.map((item, index) => reviewFindingComment(item, index));
+  const comments = value.map((item, index) => reviewFindingComment(item, index));
+  const findingIds = new Set<string>();
+  for (const comment of comments) {
+    if (findingIds.has(comment.findingId)) {
+      throw new Error(
+        `review-matrix inline_comments finding_id must be unique: ${comment.findingId}.`,
+      );
+    }
+    findingIds.add(comment.findingId);
+  }
+  return comments;
 }
 
 function reviewFindingComment(value: unknown, index: number): ReviewFindingComment {

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -37,6 +37,8 @@ interface ReviewedCommit {
 
 type ReviewFindingUpdateStatus = "outdated" | "still-present";
 
+const gitVibeAppReviewAuthors = ["gitvibe-for-github", "gitvibe-for-github[bot]"];
+
 export async function publishPullRequestReviewResult(options: {
   client: GitHubClient;
   context: ContextPacket;
@@ -320,18 +322,10 @@ async function priorReviewFindings(options: {
   const candidates = priorReviewFindingCandidates(options.context);
   if (!candidates.length) return new Map();
 
-  const login = await authenticatedGitHubLogin({
-    client: options.client,
-    eventName: "github.pr.review_thread.reconcile.skip",
-    logger: options.logger,
-    token: options.runner.token,
-  });
-  if (!login) return new Map();
-
   const findings = new Map<string, PriorReviewFinding>();
-  const updates = reviewFindingUpdatesByThread(options.context, login);
+  const updates = reviewFindingUpdatesByThread(options.context);
   for (const candidate of candidates) {
-    if (!sameGitHubLogin(candidate.author, login)) continue;
+    if (!isGitVibeAppReviewAuthor(candidate.author)) continue;
     findings.set(candidate.findingId, {
       ...candidate,
       updateKeys: updates.get(candidate.reviewThreadId) || new Set(),
@@ -360,14 +354,11 @@ function priorReviewFindingCandidates(
   return candidates;
 }
 
-function reviewFindingUpdatesByThread(
-  context: ContextPacket,
-  login: string,
-): Map<string, Set<string>> {
+function reviewFindingUpdatesByThread(context: ContextPacket): Map<string, Set<string>> {
   const updates = new Map<string, Set<string>>();
   for (const item of context.timeline) {
     if (item.kind !== "pull-request-review-comment" || !item.reviewThreadId) continue;
-    if (!sameGitHubLogin(item.author, login)) continue;
+    if (!isGitVibeAppReviewAuthor(item.author)) continue;
     const marker = parseReviewFindingUpdateMarker(item.body);
     if (!marker) continue;
     const key = reviewFindingUpdateKey(marker);
@@ -492,12 +483,23 @@ function reviewFindingComment(value: unknown, index: number): ReviewFindingComme
     reviewComment.start_line = startLine;
     reviewComment.start_side = side;
   }
+  const explicitFindingId = value.finding_id;
+  const normalizedExplicitFindingId = normalizedFindingId(explicitFindingId);
+  if (explicitFindingId !== undefined && !normalizedExplicitFindingId) {
+    throw new Error(
+      `review-matrix inline_comments[${index}].finding_id must match the allowed pattern.`,
+    );
+  }
   const findingId =
-    normalizedFindingId(value.finding_id) ||
+    normalizedExplicitFindingId ||
     parseReviewFindingMarker(rawBody)?.id ||
     generatedFindingId({ body, line, path, startLine });
   reviewComment.body = `${reviewFindingMarker(findingId)}\n${body}`;
   return { body, findingId, reviewComment };
+}
+
+function isGitVibeAppReviewAuthor(login: string): boolean {
+  return gitVibeAppReviewAuthors.some((author) => sameGitHubLogin(login, author));
 }
 
 function reviewFindingMarker(id: string): string {

--- a/src/shared/github-app-permissions.ts
+++ b/src/shared/github-app-permissions.ts
@@ -83,6 +83,7 @@ export function permissionsForProfile(
     case "server":
       return {
         actions: "write",
+        actions_variables: "read",
         contents: "write",
         discussions: "write",
         issues: "write",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,6 +75,8 @@ export interface TimelineItem {
   kind: string;
   parentId?: string;
   reactions?: JsonObject;
+  reviewThreadId?: string;
+  reviewThreadIsOutdated?: boolean;
   updatedAt?: string;
   url: string;
 }

--- a/tests/accepted-risk-run-binding.test.mjs
+++ b/tests/accepted-risk-run-binding.test.mjs
@@ -184,7 +184,7 @@ function acceptedRiskMetadata(overrides = {}) {
 }
 
 function blockedResultComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   markerArtifact = "issue",
   markerNumber = "12",

--- a/tests/accepted-risk-source-binding.test.mjs
+++ b/tests/accepted-risk-source-binding.test.mjs
@@ -123,7 +123,7 @@ function contextPacket({ artifact = "pull-request" } = {}) {
 }
 
 function timelineComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   body,
   createdAt = "2026-01-04T00:00:00Z",

--- a/tests/accepted-risk-stage-runner.test.mjs
+++ b/tests/accepted-risk-stage-runner.test.mjs
@@ -180,7 +180,7 @@ function acceptedRiskMetadataComment({ body, title = "Issue title" }) {
     html_url: "https://github.com/example/repo/issues/12#issuecomment-3",
     id: 3,
     updated_at: "2026-01-04T00:00:00Z",
-    user: { login: "github-actions[bot]" },
+    user: { login: "gitvibe-for-github[bot]" },
   };
 }
 

--- a/tests/accepted-risk.test.mjs
+++ b/tests/accepted-risk.test.mjs
@@ -252,7 +252,7 @@ describe("accepted-risk context marker rejection", () => {
 });
 
 describe("accepted-risk context trusted automation", () => {
-  it("trusts GitHub Actions metadata when author association is absent", () => {
+  it("trusts GitVibe App metadata when author association is absent", () => {
     expect(
       acceptedRiskFromContext({
         context: issueContext({
@@ -581,7 +581,7 @@ function acceptedRiskMetadata(overrides = {}) {
 }
 
 function blockedResultComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   markerArtifact = "issue",
   markerNumber = "12",
@@ -609,7 +609,7 @@ function blockedResultComment({
 
 function issueTimelineComment(body) {
   return {
-    author: "github-actions[bot]",
+    author: "gitvibe-for-github[bot]",
     authorAssociation: "NONE",
     body,
     createdAt: "2026-01-04T00:01:00Z",
@@ -620,7 +620,7 @@ function issueTimelineComment(body) {
 }
 
 function riskAcceptedAuditComment({
-  author = "github-actions[bot]",
+  author = "gitvibe-for-github[bot]",
   authorAssociation = "NONE",
   run,
   stage,

--- a/tests/content-units.test.mjs
+++ b/tests/content-units.test.mjs
@@ -194,7 +194,7 @@ describe("accepted-risk metadata context unit filtering", () => {
     };
     context.timeline = [
       {
-        author: "github-actions[bot]",
+        author: "gitvibe-for-github[bot]",
         body: resultBody,
         createdAt: "2026-01-04T00:00:00Z",
         id: "100",

--- a/tests/context-github.test.mjs
+++ b/tests/context-github.test.mjs
@@ -33,13 +33,7 @@ describe("GitHub context builders", () => {
   it("builds issue context from issue body and sorted comments", async () => {
     const client = pullRequestContextClient();
 
-    const context = await buildIssueContext({
-      client,
-      issueNumber: "4",
-      repository: "example/repo",
-      token: "token",
-      type: "pull-request",
-    });
+    const context = await buildPullRequestContext(client);
 
     expect(context.artifact).toMatchObject({
       labels: ["git-vibe:accept-risk", "custom"],
@@ -54,12 +48,12 @@ describe("GitHub context builders", () => {
       "Second",
       "<!-- git-vibe:stage-result stage=review-matrix artifact=pull-request number=4 -->\n## GitVibe Review Matrix",
       "Path: src/file.ts\nDiff:\n@@ -1 +1 @@\n\nReview feedback",
+      "Path: src/old.ts\nOutdated feedback",
     ]);
-    expect(context.timeline.at(-1)).toMatchObject({
-      id: "9",
-      kind: "pull-request-review-comment",
+    expect(context.timeline.at(-2)).toMatchObject({
+      databaseId: 9,
       parentId: "8",
-      updatedAt: "2026-01-05T01:00:00Z",
+      reviewThreadId: "thread-9",
     });
     expect(context.artifact.updatedAt).toBe("2026-01-06T00:00:00Z");
     expect(context.timeline[0].updatedAt).toBeUndefined();
@@ -188,6 +182,17 @@ describe("GitHub pull request feedback context", () => {
     );
   });
 });
+
+/** @param {MockGitHubClient} client */
+function buildPullRequestContext(client) {
+  return buildIssueContext({
+    client,
+    issueNumber: "4",
+    repository: "example/repo",
+    token: "token",
+    type: "pull-request",
+  });
+}
 
 function pullRequestContextClient() {
   return mockGitHubClient({
@@ -344,6 +349,7 @@ function reviewThreadFixture() {
           authorAssociation: "COLLABORATOR",
           body: "Review feedback",
           createdAt: "2026-01-05T00:00:00Z",
+          databaseId: 9,
           diffHunk: "@@ -1 +1 @@",
           id: "9",
           replyTo: { id: "8" },
@@ -352,6 +358,7 @@ function reviewThreadFixture() {
         },
       ],
     },
+    id: "thread-9",
     isOutdated: false,
     isResolved: false,
     path: "src/file.ts",
@@ -396,11 +403,13 @@ function filteredReviewThreadFixture(options) {
           author: { login: "reviewer" },
           body: options.body,
           createdAt: options.createdAt,
+          databaseId: Number(options.id),
           id: options.id,
           url: options.url,
         },
       ],
     },
+    id: `thread-${options.id}`,
     isOutdated: options.isOutdated || false,
     isResolved: options.isResolved || false,
     path: "src/old.ts",
@@ -669,12 +678,7 @@ describe("GitVibe config and labels", () => {
   });
 });
 
-/**
- * @param {number} status
- * @param {unknown} value
- * @param {boolean} [ok]
- * @returns {any}
- */
+/** @param {number} status @param {unknown} value @param {boolean} [ok] */
 function response(status, value, ok = status >= 200 && status < 300) {
   return {
     ok,
@@ -683,10 +687,6 @@ function response(status, value, ok = status >= 200 && status < 300) {
   };
 }
 
-/**
- * @param {Partial<MockGitHubClient>} [overrides]
- * @returns {MockGitHubClient}
- */
 function mockGitHubClient(overrides = {}) {
   return /** @type {MockGitHubClient} */ ({
     apiBaseUrl: "https://api.github.test",

--- a/tests/context-pagination.test.mjs
+++ b/tests/context-pagination.test.mjs
@@ -51,11 +51,11 @@ describe("pull request review thread pagination", () => {
                 nodes: [
                   {
                     comments: {
-                      nodes: [{ body: "First", id: "comment-1" }],
+                      nodes: [{ body: "First", databaseId: 1, id: "comment-1" }],
                       pageInfo: { hasNextPage: true, endCursor: "comment-cursor" },
                     },
                     id: "thread-1",
-                    isOutdated: false,
+                    isOutdated: true,
                     isResolved: false,
                     path: "src/a.ts",
                   },
@@ -68,7 +68,7 @@ describe("pull request review thread pagination", () => {
         .mockResolvedValueOnce({
           node: {
             comments: {
-              nodes: [{ body: "Second", id: "comment-2", path: "src/b.ts" }],
+              nodes: [{ body: "Second", databaseId: 2, id: "comment-2", path: "src/b.ts" }],
               pageInfo: { hasNextPage: false, endCursor: null },
             },
           },
@@ -79,7 +79,7 @@ describe("pull request review thread pagination", () => {
               reviewThreads: {
                 nodes: [
                   {
-                    comments: { nodes: [{ body: "Third", id: "comment-3" }] },
+                    comments: { nodes: [{ body: "Third", databaseId: 3, id: "comment-3" }] },
                     id: "thread-2",
                     isOutdated: false,
                     isResolved: false,
@@ -102,9 +102,30 @@ describe("pull request review thread pagination", () => {
         token: "token",
       }),
     ).resolves.toMatchObject([
-      { body: "First", id: "comment-1", path: "src/a.ts" },
-      { body: "Second", id: "comment-2", path: "src/b.ts" },
-      { body: "Third", id: "comment-3", path: "src/c.ts" },
+      {
+        body: "First",
+        databaseId: 1,
+        id: "comment-1",
+        path: "src/a.ts",
+        reviewThreadId: "thread-1",
+        reviewThreadIsOutdated: true,
+      },
+      {
+        body: "Second",
+        databaseId: 2,
+        id: "comment-2",
+        path: "src/b.ts",
+        reviewThreadId: "thread-1",
+        reviewThreadIsOutdated: true,
+      },
+      {
+        body: "Third",
+        databaseId: 3,
+        id: "comment-3",
+        path: "src/c.ts",
+        reviewThreadId: "thread-2",
+        reviewThreadIsOutdated: false,
+      },
     ]);
   });
 });

--- a/tests/github-app-auth.test.mjs
+++ b/tests/github-app-auth.test.mjs
@@ -221,7 +221,14 @@ describe("GitHub App installation token error handling", () => {
 
 describe("GitHub App permission profiles", () => {
   it("defines least-privilege permission profiles for server and runner tokens", () => {
-    expect(permissionsForProfile("server")).not.toHaveProperty("secrets");
+    expect(permissionsForProfile("server")).toEqual({
+      actions: "write",
+      actions_variables: "read",
+      contents: "write",
+      discussions: "write",
+      issues: "write",
+      pull_requests: "write",
+    });
     expect(permissionsForProfile("server-checks-read")).toEqual({ checks: "read" });
     expect(permissionsForProfile("server-secrets-write")).toEqual({ secrets: "write" });
     expect(permissionsForProfile("runner-read")).toEqual({

--- a/tests/pr-review-publishing-reconciliation.test.mjs
+++ b/tests/pr-review-publishing-reconciliation.test.mjs
@@ -4,7 +4,7 @@ import { publishStageResultComment } from "../src/runner/stage-publishing.ts";
 
 describe("pull request review publishing thread reconciliation", () => {
   it("replies to an existing GitVibe thread when the same finding still exists", async () => {
-    const client = createClient();
+    const client = createClient({ userLookupError: true });
 
     await publishStageResultComment({
       client,
@@ -36,6 +36,7 @@ describe("pull request review publishing thread reconciliation", () => {
     expect(reply.body.body).toContain("This issue still exists after commit `abcdef123456`.");
     expect(reply.body.body).toContain("This still misses `pull_request.labeled` handling.");
     expect(reviewRequest(client).body.comments).toBeUndefined();
+    expect(requestCalls(client).map((request) => request.path)).not.toContain("/user");
     expect(client.graphql).not.toHaveBeenCalled();
   });
 
@@ -69,7 +70,9 @@ describe("pull request review publishing thread reconciliation", () => {
       client.graphql.mock.invocationCallOrder[0],
     );
   });
+});
 
+describe("pull request review publishing thread ownership", () => {
   it("does not reconcile review threads authored by someone else", async () => {
     const client = createClient();
 
@@ -85,6 +88,26 @@ describe("pull request review publishing thread reconciliation", () => {
       "/repos/example/repo/pulls/12/comments/123/replies",
     );
     expect(client.graphql).not.toHaveBeenCalled();
+  });
+
+  it("recognizes REST-style GitVibe bot review authors", async () => {
+    const client = createClient({ userLookupError: true });
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding({ author: "gitvibe-for-github[bot]" })]),
+      logger: createLogger(),
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    const reply = requestCalls(client).find((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    expect(reply.body.body).toContain(
+      "<!-- git-vibe:review-finding-update id=review-1 status=outdated sha=abcdef123456 -->",
+    );
+    expect(requestCalls(client).map((request) => request.path)).not.toContain("/user");
   });
 });
 
@@ -228,7 +251,7 @@ function context(timeline = [], overrides = {}) {
 
 function priorReviewFinding(overrides = {}) {
   return {
-    author: "git-vibe",
+    author: "gitvibe-for-github",
     body: "<!-- git-vibe:review-finding id=review-1 -->\nOriginal GitVibe finding.",
     createdAt: "2026-01-01T00:00:00Z",
     databaseId: 123,
@@ -243,7 +266,7 @@ function priorReviewFinding(overrides = {}) {
 
 function priorFindingUpdateReply(overrides = {}) {
   return {
-    author: "git-vibe",
+    author: "gitvibe-for-github",
     body: "<!-- git-vibe:review-finding-update id=review-1 status=still-present sha=abcdef123456 -->\nAlready noted.",
     createdAt: "2026-01-01T00:01:00Z",
     databaseId: 124,
@@ -284,11 +307,15 @@ function runner() {
   };
 }
 
-function createClient() {
+function createClient(options = {}) {
   return {
     apiBaseUrl: "https://api.github.test",
     graphql: vi.fn(async () => ({})),
-    request: vi.fn(async (request) => (request.path === "/user" ? { login: "git-vibe" } : {})),
+    request: vi.fn(async (request) => {
+      if (request.path !== "/user") return {};
+      if (options.userLookupError) throw new Error("Resource not accessible by integration");
+      return { login: "git-vibe" };
+    }),
     retryBaseDelayMs: 0,
   };
 }

--- a/tests/pr-review-publishing-reconciliation.test.mjs
+++ b/tests/pr-review-publishing-reconciliation.test.mjs
@@ -1,0 +1,306 @@
+// @ts-nocheck
+import { describe, expect, it, vi } from "vitest";
+import { publishStageResultComment } from "../src/runner/stage-publishing.ts";
+
+describe("pull request review publishing thread reconciliation", () => {
+  it("replies to an existing GitVibe thread when the same finding still exists", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()]),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        findings: ["src/app.ts:42 still misses pull_request.labeled."],
+        inline_comments: [
+          {
+            body: "This still misses `pull_request.labeled` handling.",
+            finding_id: "review-1",
+            line: 42,
+            path: "src/app.ts",
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+    });
+
+    const reply = requestCalls(client).find((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    expect(reply.body.body).toContain(
+      "<!-- git-vibe:review-finding-update id=review-1 status=still-present sha=abcdef123456 -->",
+    );
+    expect(reply.body.body).toContain("This issue still exists after commit `abcdef123456`.");
+    expect(reply.body.body).toContain("This still misses `pull_request.labeled` handling.");
+    expect(reviewRequest(client).body.comments).toBeUndefined();
+    expect(client.graphql).not.toHaveBeenCalled();
+  });
+
+  it("replies that a prior GitVibe thread is outdated before resolving it", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()]),
+      logger: createLogger(),
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    const replyIndex = requestCalls(client).findIndex((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    const reply = requestCalls(client)[replyIndex];
+    expect(reply.body.body).toContain(
+      "<!-- git-vibe:review-finding-update id=review-1 status=outdated sha=abcdef123456 -->",
+    );
+    expect(reply.body.body).toContain(
+      "This GitVibe finding is outdated after commit `abcdef123456`",
+    );
+    expect(client.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("resolveReviewThread"),
+      { threadId: "thread-1" },
+      "token",
+    );
+    expect(client.request.mock.invocationCallOrder[replyIndex]).toBeLessThan(
+      client.graphql.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not reconcile review threads authored by someone else", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding({ author: "maintainer" })]),
+      logger: createLogger(),
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/comments/123/replies",
+    );
+    expect(client.graphql).not.toHaveBeenCalled();
+  });
+});
+
+describe("pull request review publishing blocked outputs", () => {
+  it("does not mark prior findings outdated when review output is blocked", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()]),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        next_state: "blocked",
+        stage: "review-matrix",
+        status: "blocked",
+        summary: "Review could not complete.",
+      },
+      runner: runner(),
+    });
+
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/comments/123/replies",
+    );
+    expect(reviewRequest(client).body.body).toContain("**Status:** `blocked`");
+    expect(client.graphql).not.toHaveBeenCalled();
+  });
+});
+
+describe("pull request review publishing reconciliation edge cases", () => {
+  it("does not duplicate an existing finding update reply for the same commit", async () => {
+    const client = createClient();
+    const logger = createLogger();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding(), priorFindingUpdateReply()]),
+      logger,
+      parsedOutput: {
+        ...output(),
+        findings: ["src/app.ts:42 still misses pull_request.labeled."],
+        inline_comments: [
+          {
+            body: "This still misses `pull_request.labeled` handling.",
+            finding_id: "review-1",
+            line: 42,
+            path: "src/app.ts",
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+    });
+
+    expect(requestCalls(client).map((request) => request.path)).not.toContain(
+      "/repos/example/repo/pulls/12/comments/123/replies",
+    );
+    expect(logger.event).toHaveBeenCalledWith("github.pr.review_thread.reply.skip", {
+      finding: "review-1",
+      reason: "duplicate-update",
+      status: "still-present",
+    });
+  });
+
+  it("ignores duplicate update markers from non-GitVibe authors", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding(), priorFindingUpdateReply({ author: "maintainer" })]),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        findings: ["src/app.ts:42 still misses pull_request.labeled."],
+        inline_comments: [
+          {
+            body: "This still misses `pull_request.labeled` handling.",
+            finding_id: "review-1",
+            line: 42,
+            path: "src/app.ts",
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+    });
+
+    const reply = requestCalls(client).find((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    expect(reply.body.body).toContain("This issue still exists after commit `abcdef123456`.");
+  });
+
+  it("uses latest reviewed commit wording when the PR head SHA is unavailable", async () => {
+    const client = createClient();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()], { pullRequestHead: undefined }),
+      logger: createLogger(),
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    const reply = requestCalls(client).find((request) =>
+      request.path.endsWith("/pulls/12/comments/123/replies"),
+    );
+    expect(reply.body.body).toContain(
+      "<!-- git-vibe:review-finding-update id=review-1 status=outdated sha=latest -->",
+    );
+    expect(reply.body.body).toContain(
+      "This GitVibe finding is outdated after the latest reviewed commit",
+    );
+  });
+});
+
+function context(timeline = [], overrides = {}) {
+  return {
+    artifact: {
+      body: "Body",
+      number: "12",
+      pullRequestHead:
+        "pullRequestHead" in overrides
+          ? overrides.pullRequestHead
+          : {
+              branch: "feature",
+              repository: "example/repo",
+              sha: "abcdef1234567890abcdef1234567890abcdef12",
+            },
+      title: "Title",
+      type: "pull-request",
+      url: "https://github.com/example/repo/pull/12",
+    },
+    generatedAt: "2026-01-01T00:00:00Z",
+    repository: "example/repo",
+    timeline,
+  };
+}
+
+function priorReviewFinding(overrides = {}) {
+  return {
+    author: "git-vibe",
+    body: "<!-- git-vibe:review-finding id=review-1 -->\nOriginal GitVibe finding.",
+    createdAt: "2026-01-01T00:00:00Z",
+    databaseId: 123,
+    id: "review-comment-node",
+    kind: "pull-request-review-comment",
+    reviewThreadId: "thread-1",
+    reviewThreadIsOutdated: false,
+    url: "https://github.com/example/repo/pull/12#discussion_r123",
+    ...overrides,
+  };
+}
+
+function priorFindingUpdateReply(overrides = {}) {
+  return {
+    author: "git-vibe",
+    body: "<!-- git-vibe:review-finding-update id=review-1 status=still-present sha=abcdef123456 -->\nAlready noted.",
+    createdAt: "2026-01-01T00:01:00Z",
+    databaseId: 124,
+    id: "review-reply-node",
+    kind: "pull-request-review-comment",
+    parentId: "review-comment-node",
+    reviewThreadId: "thread-1",
+    reviewThreadIsOutdated: false,
+    url: "https://github.com/example/repo/pull/12#discussion_r124",
+    ...overrides,
+  };
+}
+
+function output() {
+  return {
+    assumptions: [],
+    comment_body: "Result body.",
+    findings: [],
+    next_state: "ready-for-materialization",
+    references: [],
+    stage: "materialize",
+    status: "completed",
+    summary: "Result summary.",
+  };
+}
+
+function runner() {
+  return {
+    cwd: "/repo",
+    dryRun: false,
+    issueNumber: "12",
+    maxTurns: 2,
+    prNumber: "12",
+    repository: "example/repo",
+    stage: "review-matrix",
+    stageTimeoutMinutes: 1,
+    token: "token",
+  };
+}
+
+function createClient() {
+  return {
+    apiBaseUrl: "https://api.github.test",
+    graphql: vi.fn(async () => ({})),
+    request: vi.fn(async (request) => (request.path === "/user" ? { login: "git-vibe" } : {})),
+    retryBaseDelayMs: 0,
+  };
+}
+
+function createLogger() {
+  return { event: vi.fn() };
+}
+
+function requestCalls(client) {
+  return client.request.mock.calls.map((call) => call[0]);
+}
+
+function reviewRequest(client) {
+  return requestCalls(client).find((request) => request.path.endsWith("/pulls/12/reviews"));
+}

--- a/tests/pr-review-publishing.test.mjs
+++ b/tests/pr-review-publishing.test.mjs
@@ -433,6 +433,17 @@ describe("pull request review publishing validation", () => {
         [{ body: "Invalid finding ID.", finding_id: "invalid id", line: 4, path: "src/app.ts" }],
         "finding_id must match the allowed pattern",
       ],
+      [
+        [
+          { body: "Explicit duplicate.", finding_id: "review-1", line: 4, path: "src/app.ts" },
+          {
+            body: "<!-- git-vibe:review-finding id=review-1 -->\nMarker duplicate.",
+            line: 5,
+            path: "src/app.ts",
+          },
+        ],
+        "finding_id must be unique: review-1",
+      ],
     ]);
 
     for (const [inlineComments, message] of cases) {

--- a/tests/pr-review-publishing.test.mjs
+++ b/tests/pr-review-publishing.test.mjs
@@ -58,7 +58,7 @@ describe("pull request review publishing", () => {
             side: "RIGHT",
           },
           {
-            body: "The range should share the same right-side anchor.",
+            body: expect.stringContaining("The range should share the same right-side anchor."),
             line: 48,
             path: "src/app.ts",
             side: "RIGHT",
@@ -349,7 +349,7 @@ describe("pull request review publishing rerun inline comment guards", () => {
         body: expect.objectContaining({
           comments: [
             {
-              body: "New line-specific feedback.",
+              body: expect.stringContaining("New line-specific feedback."),
               line: 42,
               path: "src/app.ts",
               side: "RIGHT",
@@ -460,20 +460,22 @@ describe("pull request review publishing validation", () => {
 
 /**
  * @param {ContextPacket["artifact"]["type"]} type
+ * @param {Partial<ContextPacket> & { pullRequestHead?: ContextPacket["artifact"]["pullRequestHead"] }} [overrides]
  * @returns {ContextPacket}
  */
-function context(type) {
+function context(type, overrides = {}) {
   return {
     artifact: {
       body: "Body",
       number: "12",
+      pullRequestHead: overrides.pullRequestHead,
       title: "Title",
       type,
       url: `https://github.com/example/repo/${type}s/12`,
     },
     generatedAt: "2026-01-01T00:00:00Z",
     repository: "example/repo",
-    timeline: [],
+    timeline: overrides.timeline || [],
   };
 }
 

--- a/tests/pr-review-publishing.test.mjs
+++ b/tests/pr-review-publishing.test.mjs
@@ -429,6 +429,10 @@ describe("pull request review publishing validation", () => {
         [{ body: "Invalid range.", line: 4, path: "src/app.ts", start_line: 6 }],
         "start_line must be less than or equal to line",
       ],
+      [
+        [{ body: "Invalid finding ID.", finding_id: "invalid id", line: 4, path: "src/app.ts" }],
+        "finding_id must match the allowed pattern",
+      ],
     ]);
 
     for (const [inlineComments, message] of cases) {

--- a/tests/review-matrix-contract.test.mjs
+++ b/tests/review-matrix-contract.test.mjs
@@ -12,6 +12,7 @@ describe("review-matrix contract", () => {
       inline_comments: [
         {
           body: "Handle `pull_request.labeled` here so adding `git-vibe:review` to a PR starts review.",
+          finding_id: "review-1",
           line: 42,
           path: "src/app.ts",
           severity: "high",

--- a/tests/safety-gate-runner.test.mjs
+++ b/tests/safety-gate-runner.test.mjs
@@ -634,7 +634,7 @@ function acceptedRiskMetadataComment({ body, title = "Issue title" }) {
       "2026-01-04T00:00:00Z",
     ),
     author_association: "OWNER",
-    user: { login: "github-actions[bot]" },
+    user: { login: "gitvibe-for-github[bot]" },
   };
 }
 

--- a/tests/server-accept-risk-labels.test.mjs
+++ b/tests/server-accept-risk-labels.test.mjs
@@ -208,6 +208,18 @@ describe("GitVibe app server accept-risk pull request reviews", () => {
     expect(requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body).toContain(
       "Pull request head SHA: `head-sha`",
     );
+    expect(requestPaths(client, "DELETE")).toEqual(
+      expect.arrayContaining([
+        "/repos/example/repo/issues/12/labels/gvi%3Aready-for-approval",
+        "/repos/example/repo/issues/12/labels/gvi%3Ablocked",
+        "/repos/example/repo/issues/12/labels/gvi%3Areviewing",
+        "/repos/example/repo/issues/12/labels/gvi%3Areview-fix",
+        "/repos/example/repo/issues/12/labels/git-vibe%3Aaccept-risk",
+      ]),
+    );
+    expect(requestBodies(client, "POST", "/issues/12/labels")).toContainEqual({
+      labels: ["gvi:reviewing"],
+    });
   });
 });
 

--- a/tests/server-accept-risk-labels.test.mjs
+++ b/tests/server-accept-risk-labels.test.mjs
@@ -177,9 +177,11 @@ describe("GitVibe app server accept-risk pull request reviews", () => {
       pullRequestReviews: [
         stageResultReview({
           artifact: "pull-request",
+          authorAssociation: "NONE",
           number: 12,
           stage: "review-matrix",
           submittedAt: "2026-01-02T00:00:00Z",
+          user: "gitvibe-for-github[bot]",
         }),
       ],
     });
@@ -287,7 +289,7 @@ describe("GitVibe app server accept-risk label result selection", () => {
             submittedAt: "2026-01-03T00:00:00Z",
           }),
           author_association: "NONE",
-          user: { login: "github-actions[bot]" },
+          user: { login: "gitvibe-for-github[bot]" },
         },
         stageResultComment({
           artifact: "issue",
@@ -650,13 +652,20 @@ function stageResultComment({
   };
 }
 
-function stageResultReview({ artifact, number, stage, submittedAt = "2026-01-01T00:00:00Z" }) {
+function stageResultReview({
+  artifact,
+  authorAssociation = "OWNER",
+  number,
+  stage,
+  submittedAt = "2026-01-01T00:00:00Z",
+  user = "maintainer",
+}) {
   return {
-    author_association: "OWNER",
+    author_association: authorAssociation,
     body: stageResultBody({ artifact, number, stage }),
     id: 200,
     submitted_at: submittedAt,
-    user: { login: "maintainer" },
+    user: { login: user },
   };
 }
 

--- a/tests/server-runtime-labels.test.mjs
+++ b/tests/server-runtime-labels.test.mjs
@@ -13,14 +13,14 @@ import {
 } from "./support/server-app.mjs";
 
 describe("GitVibe app server managed runtime labels", () => {
-  it("accepts managed runtime issue labels from GitHub Actions", async () => {
+  it("accepts managed runtime issue labels from the GitVibe App bot", async () => {
     const client = createClient({ permission: new Error("GitHub API GET permission failed: 404") });
     await createApp({ client }).handleWebhook("issues", {
       action: "labeled",
       issue: { number: 11 },
       label: { name: gitVibeLabels.blocked.name },
       repository: repositoryPayload(),
-      sender: { login: "github-actions[bot]" },
+      sender: { login: "gitvibe-for-github[bot]" },
     });
 
     expect(workflowDispatches(client)).toEqual([]);
@@ -47,7 +47,7 @@ describe("GitVibe app server managed runtime labels", () => {
     );
   });
 
-  it("accepts managed runtime discussion labels from GitHub Actions", async () => {
+  it("accepts managed runtime discussion labels from the GitVibe App bot", async () => {
     const client = createClient({ permission: new Error("GitHub API GET permission failed: 404") });
     const app = createApp({ client });
 
@@ -56,7 +56,7 @@ describe("GitVibe app server managed runtime labels", () => {
       discussion: { node_id: "discussion-node", number: 5 },
       label: { name: gitVibeLabels.blocked.name, node_id: "blocked-label-node" },
       repository: repositoryPayload(),
-      sender: { login: "github-actions[bot]" },
+      sender: { login: "gitvibe-for-github[bot]" },
     });
 
     expect(workflowDispatches(client)).toEqual([]);
@@ -85,14 +85,14 @@ describe("GitVibe app server managed runtime labels", () => {
     );
   });
 
-  it("ignores managed runtime pull request label events from GitHub Actions", async () => {
+  it("ignores managed runtime pull request label events from the GitVibe App bot", async () => {
     const client = createClient({ permission: new Error("GitHub API GET permission failed: 404") });
     await createApp({ client }).handleWebhook("pull_request", {
       action: "labeled",
       label: { name: gitVibeLabels.blocked.name },
       pull_request: { number: 12 },
       repository: repositoryPayload(),
-      sender: { login: "github-actions[bot]" },
+      sender: { login: "gitvibe-for-github[bot]" },
     });
 
     expect(workflowDispatches(client)).toEqual([]);

--- a/tests/stage-contracts.test.mjs
+++ b/tests/stage-contracts.test.mjs
@@ -228,6 +228,7 @@ describe("stage prompt standards guidance", () => {
     expect(prompts.system).toContain("pull request or merge-preparation change");
     expect(prompts.prompt).toContain("PR can proceed to approval");
     expect(prompts.prompt).toContain("inline_comments");
+    expect(prompts.prompt).toContain("finding_id");
     expect(properties.inline_comments).toMatchObject({ type: "array" });
     expect(prompts.prompt).not.toContain("before PR creation");
   });

--- a/tests/stage-runner-matrix.test.mjs
+++ b/tests/stage-runner-matrix.test.mjs
@@ -692,6 +692,6 @@ function blockedResultComment({
     node_id: "review-100",
     submitted_at: "2026-01-02T00:00:00Z",
     updated_at: "2026-01-04T00:00:00Z",
-    user: { login: "github-actions[bot]" },
+    user: { login: "gitvibe-for-github[bot]" },
   };
 }


### PR DESCRIPTION
## Summary

- Promote accepted-risk handling that trusts the official `gitvibe-for-github[bot]` identity for app-owned stage results and metadata.
- Promote GitVibe PR review thread reconciliation, including stable finding IDs, prior-thread replies for persistent findings, outdated replies before thread resolution, and duplicate-comment prevention.
- Include the CodeRabbit config change that keeps incremental reviews enabled without commit-count auto-pause.

## Validation

- `corepack pnpm check`

## Notes

This promotes the current `dev` branch to `main` after PRs #52 and #53 merged into `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent review-finding IDs to track issues across reviews.
  * Reconciled PR review publishing: reply to existing threads, mark/resolve outdated threads.
  * Enabled auto-incremental review and auto-pause behaviors for automated reviews.

* **Improvements**
  * Review-thread metadata surfaced for clearer comment context and anchors.
  * Updated trusted-bot attribution for accepted-risk and label handling.
  * Server app now requests read-only Variables permission; docs updated.
  * Review-matrix now supports optional finding_id in inline comments.

* **Tests**
  * Expanded and added tests covering reconciliation, metadata, schema, and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->