### PR TITLE
Prefer rerun for accepted PR risk

### DIFF
--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -162,10 +162,9 @@ async function startAcceptedRiskWorkflow(
   plan: ResumePlan,
   result: StageResult,
 ): Promise<AcceptedRiskWorkflowDispatch | undefined> {
-  return (
-    (await rerunAcceptedRiskWorkflow(options, plan, result)) ||
-    (await dispatchAcceptedRiskWorkflow(options, label, plan))
-  );
+  const rerun = await rerunAcceptedRiskWorkflow(options, plan, result);
+  if (rerun) return rerun;
+  return dispatchAcceptedRiskWorkflow(options, label, plan);
 }
 
 async function rerunAcceptedRiskWorkflow(
@@ -176,31 +175,31 @@ async function rerunAcceptedRiskWorkflow(
   const run = result.marker.run;
   if (plan.artifact !== "pull-request" || !run) return undefined;
 
-  try {
-    const details = await workflowRunDetails(options, run);
-    if (!workflowRunMatchesPlan(details, plan)) {
-      options.log(
-        `accepted-risk rerun skipped: workflow run ${run} does not match ${plan.workflow}`,
-      );
-      return undefined;
-    }
-    const runAttempt = nextWorkflowRunAttempt(details.run_attempt);
-    if (!runAttempt) {
-      options.log(`accepted-risk rerun skipped: workflow run ${run} has no run_attempt`);
-      return undefined;
-    }
-    await rerunWorkflowRun(options, run);
-    return {
-      html_url: details.html_url,
-      ref: stringField(details.head_branch) || `run-${run}`,
-      runAttempt,
-      run_url: details.url,
-      workflow_run_id: run,
-    };
-  } catch (error) {
-    options.log(`accepted-risk workflow rerun failed: ${errorSummary(error)}`);
+  const details = await workflowRunDetails(options, run).catch((error: unknown) => {
+    if (error instanceof Error && /\bfailed: 404\b/.test(error.message)) return undefined;
+    throw error;
+  });
+  if (!details) {
+    options.log(`accepted-risk rerun skipped: workflow run ${run} is unavailable`);
     return undefined;
   }
+  if (!workflowRunMatchesPlan(details, plan)) {
+    options.log(`accepted-risk rerun skipped: workflow run ${run} does not match ${plan.workflow}`);
+    return undefined;
+  }
+  const runAttempt = nextWorkflowRunAttempt(details.run_attempt);
+  if (!runAttempt) {
+    options.log(`accepted-risk rerun skipped: workflow run ${run} has no run_attempt`);
+    return undefined;
+  }
+  await rerunWorkflowRun(options, run);
+  return {
+    html_url: details.html_url,
+    ref: stringField(details.head_branch) || `run-${run}`,
+    runAttempt,
+    run_url: details.url,
+    workflow_run_id: run,
+  };
 }
 
 async function workflowRunDetails(

--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -89,8 +89,17 @@ interface ResumePlan {
 interface AcceptedRiskWorkflowDispatch extends Record<string, unknown> {
   html_url?: string;
   ref: string;
+  runAttempt?: string;
   run_url?: string;
   workflow_run_id?: number | string;
+}
+
+interface WorkflowRunResponse extends Record<string, unknown> {
+  head_branch?: string;
+  html_url?: string;
+  path?: string;
+  run_attempt?: number | string;
+  url?: string;
 }
 
 export async function handleAcceptRiskLabel(
@@ -118,10 +127,10 @@ export async function handleAcceptRiskLabel(
   }
 
   const acceptance = await acceptedRiskMetadata(options, plan, result.marker.stage);
-  const dispatch = await dispatchAcceptedRiskWorkflow(options, label, plan);
-  if (!dispatch) return;
+  const workflowRun = await startAcceptedRiskWorkflow(options, label, plan, result);
+  if (!workflowRun) return;
 
-  const run = workflowRunIdFromDispatch(dispatch);
+  const run = workflowRunIdFromDispatch(workflowRun);
   if (!run) {
     await removeAcceptRiskLabel(options, label);
     await postAcceptRiskNoopComment(
@@ -131,7 +140,7 @@ export async function handleAcceptRiskLabel(
     return;
   }
 
-  const boundAcceptance = { ...acceptance, run };
+  const boundAcceptance = { ...acceptance, run, runAttempt: workflowRun.runAttempt };
   const stored = await storeRunBoundAcceptedRisk(options, label, result, plan, boundAcceptance);
   if (!stored) return;
 
@@ -142,8 +151,74 @@ export async function handleAcceptRiskLabel(
     number: plan.number,
     reason: `accepted prompt-injection risk for \`${result.marker.stage}\` from \`${label}\` label`,
     workflow: plan.workflow,
-    ref: dispatch.ref,
-    workflowRunUrl: dispatch.html_url,
+    ref: workflowRun.ref,
+    workflowRunUrl: workflowRun.html_url,
+  });
+}
+
+async function startAcceptedRiskWorkflow(
+  options: WebhookActionContext,
+  label: string,
+  plan: ResumePlan,
+  result: StageResult,
+): Promise<AcceptedRiskWorkflowDispatch | undefined> {
+  return (
+    (await rerunAcceptedRiskWorkflow(options, plan, result)) ||
+    (await dispatchAcceptedRiskWorkflow(options, label, plan))
+  );
+}
+
+async function rerunAcceptedRiskWorkflow(
+  options: WebhookActionContext,
+  plan: ResumePlan,
+  result: StageResult,
+): Promise<AcceptedRiskWorkflowDispatch | undefined> {
+  const run = result.marker.run;
+  if (plan.artifact !== "pull-request" || !run) return undefined;
+
+  try {
+    const details = await workflowRunDetails(options, run);
+    if (!workflowRunMatchesPlan(details, plan)) {
+      options.log(
+        `accepted-risk rerun skipped: workflow run ${run} does not match ${plan.workflow}`,
+      );
+      return undefined;
+    }
+    const runAttempt = nextWorkflowRunAttempt(details.run_attempt);
+    if (!runAttempt) {
+      options.log(`accepted-risk rerun skipped: workflow run ${run} has no run_attempt`);
+      return undefined;
+    }
+    await rerunWorkflowRun(options, run);
+    return {
+      html_url: details.html_url,
+      ref: stringField(details.head_branch) || `run-${run}`,
+      runAttempt,
+      run_url: details.url,
+      workflow_run_id: run,
+    };
+  } catch (error) {
+    options.log(`accepted-risk workflow rerun failed: ${errorSummary(error)}`);
+    return undefined;
+  }
+}
+
+async function workflowRunDetails(
+  options: WebhookActionContext,
+  run: string,
+): Promise<WorkflowRunResponse> {
+  return options.client.request<WorkflowRunResponse>({
+    method: "GET",
+    path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}`,
+    token: options.token,
+  });
+}
+
+async function rerunWorkflowRun(options: WebhookActionContext, run: string): Promise<void> {
+  await options.client.request({
+    method: "POST",
+    path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}/rerun`,
+    token: options.token,
   });
 }
 
@@ -209,6 +284,16 @@ function workflowRunIdFromDispatch(dispatch: AcceptedRiskWorkflowDispatch): stri
     workflowRunIdFromUrl(dispatch.run_url) ||
     ""
   );
+}
+
+function workflowRunMatchesPlan(details: WorkflowRunResponse, plan: ResumePlan): boolean {
+  const workflowPath = stringField(details.path).split("@")[0] || "";
+  return workflowPath.endsWith(`/${plan.workflow}`);
+}
+
+function nextWorkflowRunAttempt(value: unknown): string {
+  const attempt = Number(stringValue(value) || "");
+  return Number.isInteger(attempt) && attempt >= 1 ? String(attempt + 1) : "";
 }
 
 async function latestTrustedStageResult(

--- a/src/runner/accepted-risk.ts
+++ b/src/runner/accepted-risk.ts
@@ -67,6 +67,7 @@ export function acceptedRiskFromContext(options: {
     artifactSha: candidate.metadata.artifactSha,
     cutoff: candidate.metadata.cutoff,
     run: candidate.metadata.run,
+    runAttempt: candidate.metadata.runAttempt,
     stages: candidate.metadata.stages,
   };
 }
@@ -104,6 +105,14 @@ export function acceptedRiskApplies(options: {
       });
       return false;
     }
+  }
+  if (accepted.runAttempt && accepted.runAttempt !== options.runner.workflowRunAttempt) {
+    options.logger.event("accepted_risk.skip", {
+      accepted_attempt: accepted.runAttempt,
+      current_attempt: options.runner.workflowRunAttempt || "",
+      reason: "workflow-run-attempt-changed",
+    });
+    return false;
   }
   if (options.context.artifact.type !== "pull-request") return true;
   if (!accepted.artifactSha) {
@@ -323,7 +332,8 @@ function acceptedRiskMetadataBoundToCurrentRun(
   runner: RunnerOptions,
 ): boolean {
   const run = workflowRunIdFromUrl(runner.workflowRunUrl);
-  return Boolean(run && metadata.run && metadata.run === run);
+  if (!run || !metadata.run || metadata.run !== run) return false;
+  return !metadata.runAttempt || metadata.runAttempt === runner.workflowRunAttempt;
 }
 
 function acceptedRiskAuditForCurrentRun(context: ContextPacket, runner: RunnerOptions): boolean {

--- a/src/runner/actions/run-action.ts
+++ b/src/runner/actions/run-action.ts
@@ -75,6 +75,7 @@ export async function runAction(runtime: ActionRuntime = {}): Promise<number> {
       token,
       validationRepairAttempts: numberEnv(env, "GITVIBE_VALIDATION_REPAIR_ATTEMPTS", 3),
       validationRepairMaxTurns: numberEnv(env, "GITVIBE_VALIDATION_REPAIR_MAX_TURNS", 45),
+      workflowRunAttempt: envValue(env, "GITHUB_RUN_ATTEMPT") || undefined,
       workflowRunUrl: workflowRunUrl(env),
     });
 

--- a/src/runner/actions/security-review.ts
+++ b/src/runner/actions/security-review.ts
@@ -46,6 +46,7 @@ export async function securityReview(runtime: SecurityReviewRuntime = {}): Promi
       stage,
       stageTimeoutMinutes: numberEnv(env, "GITVIBE_STAGE_TIMEOUT_MINUTES", 10),
       token,
+      workflowRunAttempt: envValue(env, "GITHUB_RUN_ATTEMPT") || undefined,
       workflowRunUrl: workflowRunUrl(env),
     });
 

--- a/src/shared/accepted-risk.ts
+++ b/src/shared/accepted-risk.ts
@@ -15,6 +15,7 @@ export interface AcceptedRiskMetadata {
   cutoff: string;
   number: string;
   run?: string;
+  runAttempt?: string;
   stage: Stage;
   stages: Stage[];
 }
@@ -62,6 +63,7 @@ export function acceptedRiskMetadataBlock(metadata: AcceptedRiskMetadata): strin
     `${inlineCode(metadata.actor || "<unknown>")} accepted this prompt-injection input risk for one rerun.`,
     `Accepted at: ${inlineCode(metadata.cutoff)}`,
     metadata.run ? `Accepted workflow run: ${inlineCode(metadata.run)}` : "",
+    metadata.runAttempt ? `Accepted workflow attempt: ${inlineCode(metadata.runAttempt)}` : "",
     `Accepted stages: ${metadata.stages.map(inlineCode).join(", ")}`,
     `Artifact title/body SHA: ${inlineCode(metadata.artifactContentSha)}`,
     metadata.artifactSha ? `Pull request head SHA: ${inlineCode(metadata.artifactSha)}` : "",
@@ -94,6 +96,7 @@ export function parseAcceptedRiskMetadata(
       cutoff,
       number,
       run: stringField(attributes.run),
+      runAttempt: stringField(attributes["run-attempt"]),
       stage,
       stages: stagesField(attributes.stages, stage),
     };
@@ -121,6 +124,7 @@ function acceptedRiskMetadataMarker(metadata: AcceptedRiskMetadata): string {
     attribute("cutoff", metadata.cutoff),
     attribute("actor", metadata.actor || ""),
     attribute("run", metadata.run || ""),
+    attribute("run-attempt", metadata.runAttempt || ""),
     attribute("artifact-content-sha", metadata.artifactContentSha),
     attribute("artifact-sha", metadata.artifactSha || ""),
   ]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,6 +29,7 @@ export interface RunnerOptions {
     artifactSha?: string;
     cutoff: string;
     run?: string;
+    runAttempt?: string;
     stages: Stage[];
   };
   cwd: string;
@@ -50,6 +51,7 @@ export interface RunnerOptions {
   token: string;
   validationRepairAttempts?: number;
   validationRepairMaxTurns?: number;
+  workflowRunAttempt?: string;
   workflowRunUrl?: string;
 }
 

--- a/tests/accepted-risk-run-binding.test.mjs
+++ b/tests/accepted-risk-run-binding.test.mjs
@@ -44,6 +44,39 @@ describe("accepted-risk workflow run binding", () => {
     });
   });
 
+  it("derives accepted risk from metadata bound to the current workflow attempt", () => {
+    const logger = { event: vi.fn() };
+
+    expect(
+      acceptedRiskFromContext({
+        context: issueContext({
+          timeline: [
+            blockedResultComment({
+              metadata: acceptedRiskMetadata({
+                run: "99",
+                runAttempt: "3",
+                stage: "implement",
+                stages: ["implement", "create-pr"],
+              }),
+              stage: "implement",
+            }),
+          ],
+        }),
+        logger,
+        runner: runner({
+          acceptedRisk: undefined,
+          stage: "implement",
+          workflowRunAttempt: "3",
+          workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+        }),
+      }),
+    ).toMatchObject({
+      run: "99",
+      runAttempt: "3",
+      stages: ["implement", "create-pr"],
+    });
+  });
+
   it("does not use the accept-risk label as runner authority", () => {
     expect(
       acceptedRiskFromContext({
@@ -121,6 +154,33 @@ describe("accepted-risk workflow run binding rejection", () => {
       accepted_run: "88",
       current_run: "99",
       reason: "workflow-run-changed",
+    });
+  });
+
+  it("rejects explicit accepted risk when the workflow run attempt changes", () => {
+    const loggerMock = logger();
+
+    expect(
+      acceptedRiskApplies({
+        context: issueContext(),
+        logger: loggerMock,
+        runner: runner({
+          acceptedRisk: {
+            cutoff: "2026-01-04T00:00:00Z",
+            run: "99",
+            runAttempt: "2",
+            stages: ["review-matrix"],
+          },
+          stage: "review-matrix",
+          workflowRunAttempt: "3",
+          workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+        }),
+      }),
+    ).toBe(false);
+    expect(loggerMock.event).toHaveBeenCalledWith("accepted_risk.skip", {
+      accepted_attempt: "2",
+      current_attempt: "3",
+      reason: "workflow-run-attempt-changed",
     });
   });
 });

--- a/tests/run-action.test.mjs
+++ b/tests/run-action.test.mjs
@@ -36,6 +36,7 @@ describe("GitVibe action launcher", () => {
         env: {
           ...baseEnv,
           GITHUB_OUTPUT: "/tmp/output",
+          GITHUB_RUN_ATTEMPT: "3",
           GITHUB_RUN_ID: "99",
           GITHUB_SERVER_URL: "https://github.enterprise.test",
           GITVIBE_DRY_RUN: "true",
@@ -71,6 +72,7 @@ describe("GitVibe action launcher", () => {
         stageTimeoutMinutes: 34,
         validationRepairAttempts: 3,
         validationRepairMaxTurns: 45,
+        workflowRunAttempt: "3",
         workflowRunUrl: "https://github.enterprise.test/example/repo/actions/runs/99",
       }),
     );

--- a/tests/security-review-action.test.mjs
+++ b/tests/security-review-action.test.mjs
@@ -27,6 +27,7 @@ describe("GitVibe security review action", () => {
         env: {
           ...baseEnv,
           GITHUB_OUTPUT: "/tmp/output",
+          GITHUB_RUN_ATTEMPT: "3",
           GITHUB_RUN_ID: "99",
           GITHUB_SERVER_URL: "https://github.enterprise.test",
           GITVIBE_DRY_RUN: "true",
@@ -59,6 +60,7 @@ describe("GitVibe security review action", () => {
         },
         stage: "investigate",
         stageTimeoutMinutes: 7,
+        workflowRunAttempt: "3",
         workflowRunUrl: "https://github.enterprise.test/example/repo/actions/runs/99",
       }),
     );

--- a/tests/server-accept-risk-rerun.test.mjs
+++ b/tests/server-accept-risk-rerun.test.mjs
@@ -1,0 +1,102 @@
+// @ts-nocheck
+import { describe, expect, it, vi } from "vitest";
+import { gitVibeLabels } from "../src/shared/labels.ts";
+import {
+  createApp,
+  createClient,
+  repositoryPayload,
+  requestBodies,
+  requestPaths,
+  workflowDispatches,
+} from "./support/server-app.mjs";
+
+describe("GitVibe app server accept-risk pull request reruns", () => {
+  it("reruns blocked pull request review workflows and binds the next run attempt", async () => {
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRun: {
+        head_branch: "dev",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/review.yml@dev",
+        run_attempt: 2,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      },
+    });
+
+    await createApp({ client }).handleWebhook("pull_request", {
+      action: "labeled",
+      label: { name: gitVibeLabels.acceptRisk.name },
+      pull_request: { head: { sha: "head-sha" }, number: 12 },
+      repository: repositoryPayload(),
+      sender: { login: "maintainer" },
+    });
+
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
+    const updatedResult = requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body;
+    expect(updatedResult).toContain("run=88");
+    expect(updatedResult).toContain("run-attempt=3");
+    expect(updatedResult).toContain("Accepted workflow attempt: `3`");
+    expect(requestBodies(client, "POST", "/issues/12/comments").at(-1).body).toContain(
+      "Workflow run: https://github.com/example/repo/actions/runs/88",
+    );
+    expect(requestBodies(client, "POST", "/issues/12/labels")).toContainEqual({
+      labels: ["gvi:reviewing"],
+    });
+  });
+
+  it("dispatches review when the blocked result came from a different workflow", async () => {
+    const log = vi.fn();
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRun: {
+        head_branch: "dev",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/develop.yml@dev",
+        run_attempt: 2,
+      },
+    });
+
+    await createApp({ client, log }).handleWebhook("pull_request", {
+      action: "labeled",
+      label: { name: gitVibeLabels.acceptRisk.name },
+      pull_request: { head: { sha: "head-sha" }, number: 12 },
+      repository: repositoryPayload(),
+      sender: { login: "maintainer" },
+    });
+
+    expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([
+      expect.objectContaining({ inputs: { "pr-number": "12" } }),
+    ]);
+    expect(log).toHaveBeenCalledWith(
+      "accepted-risk rerun skipped: workflow run 88 does not match review.yml",
+    );
+  });
+});
+
+function stageResultReview({ run }) {
+  return {
+    author_association: "OWNER",
+    body: stageResultBody({ run }),
+    id: 200,
+    submitted_at: "2026-01-01T00:00:00Z",
+    user: { login: "maintainer" },
+  };
+}
+
+function stageResultBody({ run }) {
+  return [
+    `<!-- git-vibe:stage-result stage=review-matrix artifact=pull-request number=12 run=${run} -->`,
+    "## GitVibe Result",
+    "",
+    "**Status:** `blocked`",
+    "**Next state:** `blocked`",
+    "",
+    "GitVibe paused this run for maintainer review.",
+  ].join("\n");
+}

--- a/tests/server-accept-risk-rerun.test.mjs
+++ b/tests/server-accept-risk-rerun.test.mjs
@@ -25,13 +25,7 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
       },
     });
 
-    await createApp({ client }).handleWebhook("pull_request", {
-      action: "labeled",
-      label: { name: gitVibeLabels.acceptRisk.name },
-      pull_request: { head: { sha: "head-sha" }, number: 12 },
-      repository: repositoryPayload(),
-      sender: { login: "maintainer" },
-    });
+    await createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
 
     expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
     expect(workflowDispatches(client)).toEqual([]);
@@ -61,13 +55,7 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
       },
     });
 
-    await createApp({ client, log }).handleWebhook("pull_request", {
-      action: "labeled",
-      label: { name: gitVibeLabels.acceptRisk.name },
-      pull_request: { head: { sha: "head-sha" }, number: 12 },
-      repository: repositoryPayload(),
-      sender: { login: "maintainer" },
-    });
+    await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
 
     expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
     expect(workflowDispatches(client)).toEqual([
@@ -77,7 +65,71 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
       "accepted-risk rerun skipped: workflow run 88 does not match review.yml",
     );
   });
+
+  it("dispatches review when the prior workflow run is unavailable", async () => {
+    const log = vi.fn();
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRunError: new Error("GitHub API GET /actions/runs/88 failed: 404 {}"),
+    });
+
+    await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
+
+    expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([
+      expect.objectContaining({ inputs: { "pr-number": "12" } }),
+    ]);
+    expect(log).toHaveBeenCalledWith("accepted-risk rerun skipped: workflow run 88 is unavailable");
+  });
 });
+
+describe("GitVibe app server accept-risk pull request rerun failures", () => {
+  it("does not dispatch review when workflow run lookup fails unexpectedly", async () => {
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "404" })],
+      workflowRunError: new Error("GitHub API GET /actions/runs/404 failed: 403 {}"),
+    });
+
+    await expect(
+      createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload()),
+    ).rejects.toThrow("403");
+
+    expect(requestPaths(client, "POST")).not.toContain(
+      "/repos/example/repo/actions/runs/404/rerun",
+    );
+    expect(workflowDispatches(client)).toEqual([]);
+  });
+
+  it("does not dispatch review when rerun request fails", async () => {
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRerunError: new Error("GitHub API POST /actions/runs/88/rerun failed: 403 {}"),
+    });
+
+    await expect(
+      createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload()),
+    ).rejects.toThrow("403");
+
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
+  });
+});
+
+function acceptRiskPullRequestPayload() {
+  return {
+    action: "labeled",
+    label: { name: gitVibeLabels.acceptRisk.name },
+    pull_request: { head: { sha: "head-sha" }, number: 12 },
+    repository: repositoryPayload(),
+    sender: { login: "maintainer" },
+  };
+}
 
 function stageResultReview({ run }) {
   return {

--- a/tests/support/server-app.mjs
+++ b/tests/support/server-app.mjs
@@ -113,6 +113,22 @@ function requestResponseFor(request, options) {
     }
     throw new Error("GitHub API GET actions variable failed: 404");
   }
+  if (request.method === "GET" && /\/actions\/runs\/\d+$/.test(request.path)) {
+    if (options.workflowRunError) throw options.workflowRunError;
+    return (
+      options.workflowRun || {
+        head_branch: "main",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/review.yml@main",
+        run_attempt: 1,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      }
+    );
+  }
+  if (request.method === "POST" && /\/actions\/runs\/\d+\/rerun$/.test(request.path)) {
+    if (options.workflowRerunError) throw options.workflowRerunError;
+    return options.workflowRerunResponse || {};
+  }
   if (request.method === "GET" && request.path === "/repos/example/repo") {
     return { default_branch: options.defaultBranch || "main" };
   }


### PR DESCRIPTION
## Summary
- prefer rerunning the matching pull request review workflow when `git-vibe:accept-risk` is applied
- fall back to dispatch when the prior run is unavailable or belongs to a different workflow
- bind accepted-risk metadata to the rerun attempt so only the new attempt can consume it

## Checks
- corepack pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accepted risk labels now record and respect workflow run attempts, enabling precise rerun behavior and preventing stale acceptance carry-over
  * Workflow attempt value is propagated through run orchestration so reruns or new dispatches use the active attempt context

* **Tests**
  * Added tests covering accepted-risk binding with attempt tracking, rerun behavior, failure cases, and updated action tests to assert attempt propagation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->