### PR TITLE
Merge dev into main

### DIFF
--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -89,8 +89,17 @@ interface ResumePlan {
 interface AcceptedRiskWorkflowDispatch extends Record<string, unknown> {
   html_url?: string;
   ref: string;
+  runAttempt?: string;
   run_url?: string;
   workflow_run_id?: number | string;
+}
+
+interface WorkflowRunResponse extends Record<string, unknown> {
+  head_branch?: string;
+  html_url?: string;
+  path?: string;
+  run_attempt?: number | string;
+  url?: string;
 }
 
 export async function handleAcceptRiskLabel(
@@ -118,10 +127,10 @@ export async function handleAcceptRiskLabel(
   }
 
   const acceptance = await acceptedRiskMetadata(options, plan, result.marker.stage);
-  const dispatch = await dispatchAcceptedRiskWorkflow(options, label, plan);
-  if (!dispatch) return;
+  const workflowRun = await startAcceptedRiskWorkflow(options, label, plan, result);
+  if (!workflowRun) return;
 
-  const run = workflowRunIdFromDispatch(dispatch);
+  const run = workflowRunIdFromDispatch(workflowRun);
   if (!run) {
     await removeAcceptRiskLabel(options, label);
     await postAcceptRiskNoopComment(
@@ -131,7 +140,7 @@ export async function handleAcceptRiskLabel(
     return;
   }
 
-  const boundAcceptance = { ...acceptance, run };
+  const boundAcceptance = { ...acceptance, run, runAttempt: workflowRun.runAttempt };
   const stored = await storeRunBoundAcceptedRisk(options, label, result, plan, boundAcceptance);
   if (!stored) return;
 
@@ -142,8 +151,73 @@ export async function handleAcceptRiskLabel(
     number: plan.number,
     reason: `accepted prompt-injection risk for \`${result.marker.stage}\` from \`${label}\` label`,
     workflow: plan.workflow,
-    ref: dispatch.ref,
-    workflowRunUrl: dispatch.html_url,
+    ref: workflowRun.ref,
+    workflowRunUrl: workflowRun.html_url,
+  });
+}
+
+async function startAcceptedRiskWorkflow(
+  options: WebhookActionContext,
+  label: string,
+  plan: ResumePlan,
+  result: StageResult,
+): Promise<AcceptedRiskWorkflowDispatch | undefined> {
+  const rerun = await rerunAcceptedRiskWorkflow(options, plan, result);
+  if (rerun) return rerun;
+  return dispatchAcceptedRiskWorkflow(options, label, plan);
+}
+
+async function rerunAcceptedRiskWorkflow(
+  options: WebhookActionContext,
+  plan: ResumePlan,
+  result: StageResult,
+): Promise<AcceptedRiskWorkflowDispatch | undefined> {
+  const run = result.marker.run;
+  if (plan.artifact !== "pull-request" || !run) return undefined;
+
+  const details = await workflowRunDetails(options, run).catch((error: unknown) => {
+    if (error instanceof Error && /\bfailed: 404\b/.test(error.message)) return undefined;
+    throw error;
+  });
+  if (!details) {
+    options.log(`accepted-risk rerun skipped: workflow run ${run} is unavailable`);
+    return undefined;
+  }
+  if (!workflowRunMatchesPlan(details, plan)) {
+    options.log(`accepted-risk rerun skipped: workflow run ${run} does not match ${plan.workflow}`);
+    return undefined;
+  }
+  const runAttempt = nextWorkflowRunAttempt(details.run_attempt);
+  if (!runAttempt) {
+    options.log(`accepted-risk rerun skipped: workflow run ${run} has no run_attempt`);
+    return undefined;
+  }
+  await rerunWorkflowRun(options, run);
+  return {
+    html_url: details.html_url,
+    ref: stringField(details.head_branch) || `run-${run}`,
+    runAttempt,
+    run_url: details.url,
+    workflow_run_id: run,
+  };
+}
+
+async function workflowRunDetails(
+  options: WebhookActionContext,
+  run: string,
+): Promise<WorkflowRunResponse> {
+  return options.client.request<WorkflowRunResponse>({
+    method: "GET",
+    path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}`,
+    token: options.token,
+  });
+}
+
+async function rerunWorkflowRun(options: WebhookActionContext, run: string): Promise<void> {
+  await options.client.request({
+    method: "POST",
+    path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}/rerun`,
+    token: options.token,
   });
 }
 
@@ -209,6 +283,16 @@ function workflowRunIdFromDispatch(dispatch: AcceptedRiskWorkflowDispatch): stri
     workflowRunIdFromUrl(dispatch.run_url) ||
     ""
   );
+}
+
+function workflowRunMatchesPlan(details: WorkflowRunResponse, plan: ResumePlan): boolean {
+  const workflowPath = stringField(details.path).split("@")[0] || "";
+  return workflowPath.endsWith(`/${plan.workflow}`);
+}
+
+function nextWorkflowRunAttempt(value: unknown): string {
+  const attempt = Number(stringValue(value) || "");
+  return Number.isInteger(attempt) && attempt >= 1 ? String(attempt + 1) : "";
 }
 
 async function latestTrustedStageResult(

--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -21,10 +21,8 @@ import {
   addIssueLabel,
   createDiscussionComment,
   createIssueComment,
-  dispatchWorkflow,
   issueComments,
   postQueuedWorkflowComment,
-  repositoryWorkflowBudgetInputs,
   removeDiscussionLabelFromPayload,
   removeIssueLabelIfPresent,
   type WebhookActionContext,
@@ -80,7 +78,6 @@ interface StageResultSource {
 
 interface ResumePlan {
   artifact: "discussion" | "issue" | "pull-request";
-  inputName: "discussion-number" | "issue-number" | "pr-number";
   number: string;
   riskStages: Stage[];
   workflow: string;
@@ -137,7 +134,7 @@ export async function handleAcceptRiskLabel(
     await removeAcceptRiskLabel(options, label);
     await postAcceptRiskNoopComment(
       options,
-      `GitVibe removed \`${label}\` because GitHub did not return a workflow run id for the accepted-risk rerun. Apply the label again after GitHub workflow dispatch run details are available.`,
+      `GitVibe removed \`${label}\` because GitHub did not return a workflow run id for the accepted-risk rerun.`,
     );
     return;
   }
@@ -168,7 +165,12 @@ async function startAcceptedRiskWorkflow(
 ): Promise<AcceptedRiskWorkflowDispatch | undefined> {
   const rerun = await rerunAcceptedRiskWorkflow(options, plan, result, acceptance);
   if (rerun) return rerun;
-  return dispatchAcceptedRiskWorkflow(options, label, plan);
+  await removeAcceptRiskLabel(options, label);
+  await postAcceptRiskNoopComment(
+    options,
+    `GitVibe removed \`${label}\` because it could not safely rerun the blocked \`${result.marker.stage}\` workflow run for accepted-risk. Re-run the stage manually after checking the blocked result still points to a matching workflow run.`,
+  );
+  return undefined;
 }
 
 async function rerunAcceptedRiskWorkflow(
@@ -178,7 +180,10 @@ async function rerunAcceptedRiskWorkflow(
   acceptance: AcceptedRiskMetadata,
 ): Promise<AcceptedRiskWorkflowDispatch | undefined> {
   const run = result.marker.run;
-  if (plan.artifact !== "pull-request" || !run) return undefined;
+  if (!run) {
+    options.log("accepted-risk rerun skipped: blocked stage result has no workflow run id");
+    return undefined;
+  }
 
   const details = await options.client
     .request<WorkflowRunResponse>({
@@ -199,7 +204,7 @@ async function rerunAcceptedRiskWorkflow(
     return undefined;
   }
   const runHeadSha = stringField(details.head_sha);
-  if (!runHeadSha || runHeadSha !== acceptance.artifactSha) {
+  if (plan.artifact === "pull-request" && (!runHeadSha || runHeadSha !== acceptance.artifactSha)) {
     options.log(`accepted-risk rerun skipped: workflow run ${run} head SHA does not match`);
     return undefined;
   }
@@ -222,27 +227,6 @@ async function rerunAcceptedRiskWorkflow(
     },
     workflow_run_id: run,
   };
-}
-
-async function dispatchAcceptedRiskWorkflow(
-  options: WebhookActionContext,
-  label: string,
-  plan: ResumePlan,
-): Promise<AcceptedRiskWorkflowDispatch | undefined> {
-  try {
-    return await dispatchWorkflow(options, plan.workflow, {
-      ...(await repositoryWorkflowBudgetInputs(options, plan.workflow)),
-      [plan.inputName]: plan.number,
-    });
-  } catch (error) {
-    await removeAcceptRiskLabel(options, label);
-    options.log(`accepted-risk workflow dispatch failed: ${errorSummary(error)}`);
-    await postAcceptRiskNoopComment(
-      options,
-      `GitVibe removed \`${label}\` because it could not queue a run-bound accepted-risk workflow.`,
-    );
-    return undefined;
-  }
 }
 
 async function storeRunBoundAcceptedRisk(
@@ -290,7 +274,16 @@ function workflowRunIdFromDispatch(dispatch: AcceptedRiskWorkflowDispatch): stri
 
 function workflowRunMatchesPlan(details: WorkflowRunResponse, plan: ResumePlan): boolean {
   const workflowPath = stringField(details.path).split("@")[0] || "";
-  return workflowPath.endsWith(`/${plan.workflow}`);
+  return workflowPathsForPlan(plan).some(
+    (candidate) => workflowPath === candidate || workflowPath.endsWith(`/${candidate}`),
+  );
+}
+
+function workflowPathsForPlan(plan: ResumePlan): string[] {
+  if (plan.artifact === "pull-request" && plan.workflow === "review.yml") {
+    return [plan.workflow, ".github/workflows/automatic-pr-review.yml"];
+  }
+  return [plan.workflow];
 }
 
 function nextWorkflowRunAttempt(value: unknown): string {
@@ -399,7 +392,6 @@ function resumePlanFor(
     if (marker.stage === "validate") {
       return {
         artifact: "discussion",
-        inputName: "discussion-number",
         number,
         riskStages: [marker.stage],
         workflow: "validate.yml",
@@ -408,7 +400,6 @@ function resumePlanFor(
     if (marker.stage === "materialize") {
       return {
         artifact: "discussion",
-        inputName: "discussion-number",
         number,
         riskStages: [marker.stage],
         workflow: "materialize.yml",
@@ -425,7 +416,6 @@ function issueResumePlan(marker: StageResultMarker): ResumePlan | undefined {
   if (marker.stage === "investigate") {
     return {
       artifact: "issue",
-      inputName: "issue-number",
       number,
       riskStages: [marker.stage],
       workflow: "investigate.yml",
@@ -434,7 +424,6 @@ function issueResumePlan(marker: StageResultMarker): ResumePlan | undefined {
   if (marker.stage === "validate") {
     return {
       artifact: "issue",
-      inputName: "issue-number",
       number,
       riskStages: [marker.stage],
       workflow: "validate.yml",
@@ -443,7 +432,6 @@ function issueResumePlan(marker: StageResultMarker): ResumePlan | undefined {
   if (marker.stage === "implement" || marker.stage === "create-pr") {
     return {
       artifact: "issue",
-      inputName: "issue-number",
       number,
       riskStages: ["implement", "create-pr"],
       workflow: "develop.yml",
@@ -457,7 +445,6 @@ function pullRequestResumePlan(marker: StageResultMarker): ResumePlan | undefine
   if (marker.stage === "review-matrix") {
     return {
       artifact: "pull-request",
-      inputName: "pr-number",
       number,
       riskStages: [marker.stage],
       workflow: "review.yml",
@@ -466,7 +453,6 @@ function pullRequestResumePlan(marker: StageResultMarker): ResumePlan | undefine
   if (marker.stage === "investigate" || marker.stage === "address-pr-feedback") {
     return {
       artifact: "pull-request",
-      inputName: "pr-number",
       number,
       riskStages: ["investigate", "address-pr-feedback"],
       workflow: "address-feedback.yml",

--- a/src/app/accept-risk-labels.ts
+++ b/src/app/accept-risk-labels.ts
@@ -91,11 +91,13 @@ interface AcceptedRiskWorkflowDispatch extends Record<string, unknown> {
   ref: string;
   runAttempt?: string;
   run_url?: string;
+  startAfterMetadata?: () => Promise<void>;
   workflow_run_id?: number | string;
 }
 
 interface WorkflowRunResponse extends Record<string, unknown> {
   head_branch?: string;
+  head_sha?: string;
   html_url?: string;
   path?: string;
   run_attempt?: number | string;
@@ -127,7 +129,7 @@ export async function handleAcceptRiskLabel(
   }
 
   const acceptance = await acceptedRiskMetadata(options, plan, result.marker.stage);
-  const workflowRun = await startAcceptedRiskWorkflow(options, label, plan, result);
+  const workflowRun = await startAcceptedRiskWorkflow(options, label, plan, result, acceptance);
   if (!workflowRun) return;
 
   const run = workflowRunIdFromDispatch(workflowRun);
@@ -144,6 +146,7 @@ export async function handleAcceptRiskLabel(
   const stored = await storeRunBoundAcceptedRisk(options, label, result, plan, boundAcceptance);
   if (!stored) return;
 
+  await workflowRun.startAfterMetadata?.();
   await markAcceptedRiskWorkflowRunning(options, plan);
   await removeAcceptRiskLabel(options, label);
   await postQueuedWorkflowComment(options, {
@@ -161,8 +164,9 @@ async function startAcceptedRiskWorkflow(
   label: string,
   plan: ResumePlan,
   result: StageResult,
+  acceptance: AcceptedRiskMetadata,
 ): Promise<AcceptedRiskWorkflowDispatch | undefined> {
-  const rerun = await rerunAcceptedRiskWorkflow(options, plan, result);
+  const rerun = await rerunAcceptedRiskWorkflow(options, plan, result, acceptance);
   if (rerun) return rerun;
   return dispatchAcceptedRiskWorkflow(options, label, plan);
 }
@@ -171,14 +175,21 @@ async function rerunAcceptedRiskWorkflow(
   options: WebhookActionContext,
   plan: ResumePlan,
   result: StageResult,
+  acceptance: AcceptedRiskMetadata,
 ): Promise<AcceptedRiskWorkflowDispatch | undefined> {
   const run = result.marker.run;
   if (plan.artifact !== "pull-request" || !run) return undefined;
 
-  const details = await workflowRunDetails(options, run).catch((error: unknown) => {
-    if (error instanceof Error && /\bfailed: 404\b/.test(error.message)) return undefined;
-    throw error;
-  });
+  const details = await options.client
+    .request<WorkflowRunResponse>({
+      method: "GET",
+      path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}`,
+      token: options.token,
+    })
+    .catch((error: unknown) => {
+      if (error instanceof Error && /\bfailed: 404\b/.test(error.message)) return undefined;
+      throw error;
+    });
   if (!details) {
     options.log(`accepted-risk rerun skipped: workflow run ${run} is unavailable`);
     return undefined;
@@ -187,38 +198,30 @@ async function rerunAcceptedRiskWorkflow(
     options.log(`accepted-risk rerun skipped: workflow run ${run} does not match ${plan.workflow}`);
     return undefined;
   }
+  const runHeadSha = stringField(details.head_sha);
+  if (!runHeadSha || runHeadSha !== acceptance.artifactSha) {
+    options.log(`accepted-risk rerun skipped: workflow run ${run} head SHA does not match`);
+    return undefined;
+  }
   const runAttempt = nextWorkflowRunAttempt(details.run_attempt);
   if (!runAttempt) {
     options.log(`accepted-risk rerun skipped: workflow run ${run} has no run_attempt`);
     return undefined;
   }
-  await rerunWorkflowRun(options, run);
   return {
     html_url: details.html_url,
     ref: stringField(details.head_branch) || `run-${run}`,
     runAttempt,
     run_url: details.url,
+    startAfterMetadata: async () => {
+      await options.client.request({
+        method: "POST",
+        path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}/rerun`,
+        token: options.token,
+      });
+    },
     workflow_run_id: run,
   };
-}
-
-async function workflowRunDetails(
-  options: WebhookActionContext,
-  run: string,
-): Promise<WorkflowRunResponse> {
-  return options.client.request<WorkflowRunResponse>({
-    method: "GET",
-    path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}`,
-    token: options.token,
-  });
-}
-
-async function rerunWorkflowRun(options: WebhookActionContext, run: string): Promise<void> {
-  await options.client.request({
-    method: "POST",
-    path: `/repos/${options.owner}/${options.repo}/actions/runs/${run}/rerun`,
-    token: options.token,
-  });
 }
 
 async function dispatchAcceptedRiskWorkflow(

--- a/src/runner/accepted-risk.ts
+++ b/src/runner/accepted-risk.ts
@@ -31,6 +31,7 @@ interface AcceptedRiskAuditMarker {
   artifact?: string;
   number?: string;
   run?: string;
+  "run-attempt"?: string;
   stage?: string;
 }
 
@@ -210,13 +211,15 @@ function acceptedRiskAuditBody(options: {
   const cutoff = options.runner.acceptedRisk?.cutoff;
   const run = workflowRunIdFromUrl(options.runner.workflowRunUrl);
   const runAttribute = run ? ` run=${run}` : "";
+  const attempt = options.runner.workflowRunAttempt;
+  const attemptAttribute = attempt ? ` run-attempt=${attempt}` : "";
   const riskLine = options.result
     ? "The high-risk findings remain visible in the GitVibe blocked result above."
     : cutoff
       ? `GitVibe did not detect high-risk prompt-injection content in context created or edited after \`${cutoff}\`.`
       : "The security scan did not detect high-risk prompt-injection content in this run.";
   return [
-    `<!-- git-vibe:risk-accepted stage=${options.runner.stage} artifact=${options.context.artifact.type} number=${options.context.artifact.number}${runAttribute} -->`,
+    `<!-- git-vibe:risk-accepted stage=${options.runner.stage} artifact=${options.context.artifact.type} number=${options.context.artifact.number}${runAttribute}${attemptAttribute} -->`,
     "## GitVibe Risk Accepted",
     "",
     `${actorLabel(actor)} accepted prompt-injection input risk for one \`${options.runner.stage}\` run.`,
@@ -345,9 +348,18 @@ function acceptedRiskAuditForCurrentRun(context: ContextPacket, runner: RunnerOp
     return (
       marker?.artifact === context.artifact.type &&
       marker.number === context.artifact.number &&
-      marker.run === run
+      marker.run === run &&
+      auditMarkerAttemptMatches(marker, runner)
     );
   });
+}
+
+function auditMarkerAttemptMatches(
+  marker: AcceptedRiskAuditMarker,
+  runner: RunnerOptions,
+): boolean {
+  const attempt = stringValue(runner.workflowRunAttempt);
+  return !attempt || marker["run-attempt"] === attempt;
 }
 
 function parseAcceptedRiskAuditMarker(
@@ -380,6 +392,7 @@ function acceptedRiskMetadataMatches(options: {
     options.metadata.number === options.context.artifact.number &&
     options.metadata.cutoff === options.accepted.cutoff &&
     (!options.accepted.run || options.metadata.run === options.accepted.run) &&
+    (!options.accepted.runAttempt || options.metadata.runAttempt === options.accepted.runAttempt) &&
     options.metadata.stages.includes(options.runner.stage)
   );
 }

--- a/src/runner/accepted-risk.ts
+++ b/src/runner/accepted-risk.ts
@@ -67,6 +67,7 @@ export function acceptedRiskFromContext(options: {
     artifactSha: candidate.metadata.artifactSha,
     cutoff: candidate.metadata.cutoff,
     run: candidate.metadata.run,
+    runAttempt: candidate.metadata.runAttempt,
     stages: candidate.metadata.stages,
   };
 }
@@ -104,6 +105,14 @@ export function acceptedRiskApplies(options: {
       });
       return false;
     }
+  }
+  if (accepted.runAttempt && accepted.runAttempt !== options.runner.workflowRunAttempt) {
+    options.logger.event("accepted_risk.skip", {
+      accepted_attempt: accepted.runAttempt,
+      current_attempt: options.runner.workflowRunAttempt || "",
+      reason: "workflow-run-attempt-changed",
+    });
+    return false;
   }
   if (options.context.artifact.type !== "pull-request") return true;
   if (!accepted.artifactSha) {
@@ -323,7 +332,8 @@ function acceptedRiskMetadataBoundToCurrentRun(
   runner: RunnerOptions,
 ): boolean {
   const run = workflowRunIdFromUrl(runner.workflowRunUrl);
-  return Boolean(run && metadata.run && metadata.run === run);
+  if (!run || !metadata.run || metadata.run !== run) return false;
+  return !metadata.runAttempt || metadata.runAttempt === runner.workflowRunAttempt;
 }
 
 function acceptedRiskAuditForCurrentRun(context: ContextPacket, runner: RunnerOptions): boolean {

--- a/src/runner/actions/run-action.ts
+++ b/src/runner/actions/run-action.ts
@@ -75,6 +75,7 @@ export async function runAction(runtime: ActionRuntime = {}): Promise<number> {
       token,
       validationRepairAttempts: numberEnv(env, "GITVIBE_VALIDATION_REPAIR_ATTEMPTS", 3),
       validationRepairMaxTurns: numberEnv(env, "GITVIBE_VALIDATION_REPAIR_MAX_TURNS", 45),
+      workflowRunAttempt: envValue(env, "GITHUB_RUN_ATTEMPT") || undefined,
       workflowRunUrl: workflowRunUrl(env),
     });
 

--- a/src/runner/actions/security-review.ts
+++ b/src/runner/actions/security-review.ts
@@ -46,6 +46,7 @@ export async function securityReview(runtime: SecurityReviewRuntime = {}): Promi
       stage,
       stageTimeoutMinutes: numberEnv(env, "GITVIBE_STAGE_TIMEOUT_MINUTES", 10),
       token,
+      workflowRunAttempt: envValue(env, "GITHUB_RUN_ATTEMPT") || undefined,
       workflowRunUrl: workflowRunUrl(env),
     });
 

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { GitHubClient, splitRepository } from "../shared/github.js";
+import { GitHubClient, isGitHubGraphQLForbiddenError, splitRepository } from "../shared/github.js";
 import { workflowRunIdFromUrl } from "../shared/status-comments.js";
 import type { ContextPacket, JsonObject, RunnerOptions } from "../shared/types.js";
 import type { StageLogger } from "./logging.js";
@@ -438,17 +438,18 @@ async function resolveReviewThread(options: {
   reviewThreadId: string;
   token: string;
 }): Promise<void> {
-  options.logger.event("github.pr.review_thread.resolve.start", {
-    thread: options.reviewThreadId,
-  });
-  await options.client.graphql(
-    resolveReviewThreadMutation,
-    { threadId: options.reviewThreadId },
-    options.token,
-  );
-  options.logger.event("github.pr.review_thread.resolve.done", {
-    thread: options.reviewThreadId,
-  });
+  const thread = options.reviewThreadId;
+  options.logger.event("github.pr.review_thread.resolve.start", { thread });
+  try {
+    await options.client.graphql(resolveReviewThreadMutation, { threadId: thread }, options.token);
+  } catch (error) {
+    if (isGitHubGraphQLForbiddenError(error, "resolveReviewThread")) {
+      options.logger.event("github.pr.review_thread.resolve.skip", { reason: "forbidden", thread });
+      return;
+    }
+    throw error;
+  }
+  options.logger.event("github.pr.review_thread.resolve.done", { thread });
 }
 
 function reviewFindingComments(value: unknown): ReviewFindingComment[] {

--- a/src/runner/safety-gate.ts
+++ b/src/runner/safety-gate.ts
@@ -101,6 +101,7 @@ const suspiciousLinkedFilePattern =
   /\.(?:7z|apk|app|bat|bash|cmd|deb|dmg|exe|jar|msi|pkg|ps1|rar|rpm|sh|tar|tgz|war|xz|zip)(?:[?#]|$)/iu;
 const riskyLinkActionPattern =
   /\b(?:curl|download|execute|fetch|install|open|read|run|source|wget)\b/iu;
+const maxSafetyMatchExcerptLength = 160;
 
 export function safetyGateForStage(options: {
   config: GitVibeConfig;
@@ -275,9 +276,13 @@ function patternMatches(
   patterns: Array<{ finding: string; regex: RegExp }>,
   severity: Exclude<SafetySeverity, "none">,
 ): PatternMatch[] {
-  return patterns.flatMap((pattern) =>
-    pattern.regex.test(text) ? [{ finding: `${label}: ${pattern.finding}`, severity }] : [],
-  );
+  return patterns.flatMap((pattern) => {
+    pattern.regex.lastIndex = 0;
+    const match = pattern.regex.exec(text);
+    pattern.regex.lastIndex = 0;
+    if (!match?.[0]) return [];
+    return [{ finding: findingWithMatchedExcerpt(label, pattern.finding, text, match), severity }];
+  });
 }
 
 function base64Matches(source: SafetySource): PatternMatch[] {
@@ -401,6 +406,35 @@ function safetySourceUnit(source: SafetySource, id: string): ContentUnit {
 
 function normalizedText(value: string): string {
   return value.normalize("NFKC").replace(/[\u200b-\u200f\u202a-\u202e\u2066-\u2069]/gu, "");
+}
+
+function findingWithMatchedExcerpt(
+  label: string,
+  finding: string,
+  source: string,
+  match: RegExpExecArray,
+): string {
+  const excerpt = safetyMatchExcerpt(source, match.index, match[0].length);
+  const suffix = excerpt ? ` (matched excerpt: ${inlineCode(excerpt)})` : "";
+  return `${label}: ${finding}${suffix}`;
+}
+
+function safetyMatchExcerpt(value: string, start: number, length: number): string {
+  const windowStart = Math.max(0, start - 48);
+  const windowEnd = Math.min(value.length, start + length + 48);
+  const prefix = windowStart > 0 ? "..." : "";
+  const suffix = windowEnd < value.length ? "..." : "";
+  const text = `${prefix}${normalizedText(value.slice(windowStart, windowEnd))
+    .replace(/\s+/gu, " ")
+    .trim()}${suffix}`;
+  if (!text) return "";
+  const chars = [...text];
+  if (chars.length <= maxSafetyMatchExcerptLength) return text;
+  return `${chars.slice(0, maxSafetyMatchExcerptLength - 3).join("")}...`;
+}
+
+function inlineCode(value: string): string {
+  return `\`${value.replaceAll("`", "'")}\``;
 }
 
 function validBase64Candidate(value: string): boolean {

--- a/src/shared/accepted-risk.ts
+++ b/src/shared/accepted-risk.ts
@@ -15,6 +15,7 @@ export interface AcceptedRiskMetadata {
   cutoff: string;
   number: string;
   run?: string;
+  runAttempt?: string;
   stage: Stage;
   stages: Stage[];
 }
@@ -62,6 +63,7 @@ export function acceptedRiskMetadataBlock(metadata: AcceptedRiskMetadata): strin
     `${inlineCode(metadata.actor || "<unknown>")} accepted this prompt-injection input risk for one rerun.`,
     `Accepted at: ${inlineCode(metadata.cutoff)}`,
     metadata.run ? `Accepted workflow run: ${inlineCode(metadata.run)}` : "",
+    metadata.runAttempt ? `Accepted workflow attempt: ${inlineCode(metadata.runAttempt)}` : "",
     `Accepted stages: ${metadata.stages.map(inlineCode).join(", ")}`,
     `Artifact title/body SHA: ${inlineCode(metadata.artifactContentSha)}`,
     metadata.artifactSha ? `Pull request head SHA: ${inlineCode(metadata.artifactSha)}` : "",
@@ -94,6 +96,7 @@ export function parseAcceptedRiskMetadata(
       cutoff,
       number,
       run: stringField(attributes.run),
+      runAttempt: stringField(attributes["run-attempt"]),
       stage,
       stages: stagesField(attributes.stages, stage),
     };
@@ -121,6 +124,7 @@ function acceptedRiskMetadataMarker(metadata: AcceptedRiskMetadata): string {
     attribute("cutoff", metadata.cutoff),
     attribute("actor", metadata.actor || ""),
     attribute("run", metadata.run || ""),
+    attribute("run-attempt", metadata.runAttempt || ""),
     attribute("artifact-content-sha", metadata.artifactContentSha),
     attribute("artifact-sha", metadata.artifactSha || ""),
   ]

--- a/src/shared/github.ts
+++ b/src/shared/github.ts
@@ -85,6 +85,16 @@ export class GitHubClient {
   }
 }
 
+export function isGitHubGraphQLForbiddenError(error: unknown, path: string): boolean {
+  const message = error instanceof Error ? error.message : "";
+  return (
+    message.startsWith("GitHub GraphQL failed: ") &&
+    message.includes('"type":"FORBIDDEN"') &&
+    message.includes(`"path":["${path}"]`) &&
+    message.includes("Resource not accessible by integration")
+  );
+}
+
 export async function paginatedGitHubRequest<T = unknown>(
   client: Pick<GitHubClient, "request">,
   request: GitHubRequest,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,6 +29,7 @@ export interface RunnerOptions {
     artifactSha?: string;
     cutoff: string;
     run?: string;
+    runAttempt?: string;
     stages: Stage[];
   };
   cwd: string;
@@ -50,6 +51,7 @@ export interface RunnerOptions {
   token: string;
   validationRepairAttempts?: number;
   validationRepairMaxTurns?: number;
+  workflowRunAttempt?: string;
   workflowRunUrl?: string;
 }
 

--- a/tests/accepted-risk-run-binding.test.mjs
+++ b/tests/accepted-risk-run-binding.test.mjs
@@ -99,6 +99,37 @@ describe("accepted-risk workflow run binding", () => {
   });
 });
 
+describe("accepted-risk workflow run audit binding", () => {
+  it("derives accepted risk from audit markers bound to the current workflow attempt", () => {
+    expect(
+      acceptedRiskFromContext({
+        context: issueContext({
+          timeline: [
+            blockedResultComment({
+              metadata: acceptedRiskMetadata({
+                stage: "implement",
+                stages: ["implement", "create-pr"],
+              }),
+              stage: "implement",
+            }),
+            riskAcceptedAuditComment({ run: "99", runAttempt: "3", stage: "implement" }),
+          ],
+        }),
+        logger: logger(),
+        runner: runner({
+          acceptedRisk: undefined,
+          stage: "create-pr",
+          workflowRunAttempt: "3",
+          workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+        }),
+      }),
+    ).toMatchObject({
+      cutoff: "2026-01-04T00:00:00Z",
+      stages: ["implement", "create-pr"],
+    });
+  });
+});
+
 describe("accepted-risk workflow run binding rejection", () => {
   it("ignores metadata bound to a different workflow run", () => {
     const loggerMock = logger();
@@ -185,6 +216,43 @@ describe("accepted-risk workflow run binding rejection", () => {
   });
 });
 
+describe("accepted-risk workflow run audit binding rejection", () => {
+  it("ignores run audit markers without the current workflow attempt", () => {
+    const metadata = acceptedRiskMetadata({ stage: "implement", stages: ["implement"] });
+    const runnerOptions = runner({
+      acceptedRisk: undefined,
+      stage: "implement",
+      workflowRunAttempt: "3",
+      workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+    });
+
+    expect(
+      acceptedRiskFromContext({
+        context: issueContext({
+          timeline: [
+            blockedResultComment({ metadata, stage: "implement" }),
+            riskAcceptedAuditComment({ run: "99", stage: "implement" }),
+          ],
+        }),
+        logger: logger(),
+        runner: runnerOptions,
+      }),
+    ).toBeUndefined();
+    expect(
+      acceptedRiskFromContext({
+        context: issueContext({
+          timeline: [
+            blockedResultComment({ metadata, stage: "implement" }),
+            riskAcceptedAuditComment({ run: "99", runAttempt: "2", stage: "implement" }),
+          ],
+        }),
+        logger: logger(),
+        runner: runnerOptions,
+      }),
+    ).toBeUndefined();
+  });
+});
+
 function logger() {
   return { event: vi.fn() };
 }
@@ -267,5 +335,21 @@ function blockedResultComment({
     id: "100",
     kind: "comment",
     url: "https://github.com/example/repo/issues/12#issuecomment-100",
+  };
+}
+
+function riskAcceptedAuditComment({ run, runAttempt, stage }) {
+  const attemptAttribute = runAttempt ? ` run-attempt=${runAttempt}` : "";
+  return {
+    author: "gitvibe-for-github[bot]",
+    authorAssociation: "NONE",
+    body: [
+      `<!-- git-vibe:risk-accepted stage=${stage} artifact=issue number=12 run=${run}${attemptAttribute} -->`,
+      "## GitVibe Risk Accepted",
+    ].join("\n"),
+    createdAt: "2026-01-04T00:01:00Z",
+    id: "101",
+    kind: "comment",
+    url: "https://github.com/example/repo/issues/12#issuecomment-101",
   };
 }

--- a/tests/accepted-risk-run-binding.test.mjs
+++ b/tests/accepted-risk-run-binding.test.mjs
@@ -44,6 +44,39 @@ describe("accepted-risk workflow run binding", () => {
     });
   });
 
+  it("derives accepted risk from metadata bound to the current workflow attempt", () => {
+    const logger = { event: vi.fn() };
+
+    expect(
+      acceptedRiskFromContext({
+        context: issueContext({
+          timeline: [
+            blockedResultComment({
+              metadata: acceptedRiskMetadata({
+                run: "99",
+                runAttempt: "3",
+                stage: "implement",
+                stages: ["implement", "create-pr"],
+              }),
+              stage: "implement",
+            }),
+          ],
+        }),
+        logger,
+        runner: runner({
+          acceptedRisk: undefined,
+          stage: "implement",
+          workflowRunAttempt: "3",
+          workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+        }),
+      }),
+    ).toMatchObject({
+      run: "99",
+      runAttempt: "3",
+      stages: ["implement", "create-pr"],
+    });
+  });
+
   it("does not use the accept-risk label as runner authority", () => {
     expect(
       acceptedRiskFromContext({
@@ -121,6 +154,33 @@ describe("accepted-risk workflow run binding rejection", () => {
       accepted_run: "88",
       current_run: "99",
       reason: "workflow-run-changed",
+    });
+  });
+
+  it("rejects explicit accepted risk when the workflow run attempt changes", () => {
+    const loggerMock = logger();
+
+    expect(
+      acceptedRiskApplies({
+        context: issueContext(),
+        logger: loggerMock,
+        runner: runner({
+          acceptedRisk: {
+            cutoff: "2026-01-04T00:00:00Z",
+            run: "99",
+            runAttempt: "2",
+            stages: ["review-matrix"],
+          },
+          stage: "review-matrix",
+          workflowRunAttempt: "3",
+          workflowRunUrl: "https://github.com/example/repo/actions/runs/99",
+        }),
+      }),
+    ).toBe(false);
+    expect(loggerMock.event).toHaveBeenCalledWith("accepted_risk.skip", {
+      accepted_attempt: "2",
+      current_attempt: "3",
+      reason: "workflow-run-attempt-changed",
     });
   });
 });

--- a/tests/accepted-risk.test.mjs
+++ b/tests/accepted-risk.test.mjs
@@ -299,10 +299,12 @@ describe("accepted-risk audit publishing", () => {
           cutoff: "2026-01-04T00:00:00Z",
           stages: ["investigate"],
         },
+        workflowRunAttempt: "3",
       }),
     });
 
     const comment = client.request.mock.calls.find(([request]) => request.method === "POST")?.[0];
+    expect(comment.body.body).toContain("run-attempt=3");
     expect(comment.body.body).toContain("`bad'actor` accepted prompt-injection input risk");
     expect(comment.body.body).toContain("The high-risk findings remain visible");
     expect(client.request.mock.calls.at(-1)[0]).toMatchObject({ method: "DELETE" });

--- a/tests/pr-review-publishing-reconciliation.test.mjs
+++ b/tests/pr-review-publishing-reconciliation.test.mjs
@@ -72,6 +72,50 @@ describe("pull request review publishing thread reconciliation", () => {
   });
 });
 
+describe("pull request review publishing thread resolution failures", () => {
+  it("keeps publishing when resolving an outdated GitVibe thread is forbidden", async () => {
+    const client = createClient({
+      graphqlError: new Error(
+        'GitHub GraphQL failed: [{"type":"FORBIDDEN","path":["resolveReviewThread"],"message":"Resource not accessible by integration"}]',
+      ),
+    });
+    const logger = createLogger();
+
+    await publishStageResultComment({
+      client,
+      context: context([priorReviewFinding()]),
+      logger,
+      parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+      runner: runner(),
+    });
+
+    expect(requestCalls(client).map((request) => request.path)).toContain(
+      "/repos/example/repo/pulls/12/comments/123/replies",
+    );
+    expect(reviewRequest(client).body.body).toContain("**Status:** `completed`");
+    expect(logger.event).toHaveBeenCalledWith("github.pr.review_thread.resolve.skip", {
+      reason: "forbidden",
+      thread: "thread-1",
+    });
+  });
+
+  it("fails publishing when resolving an outdated GitVibe thread fails unexpectedly", async () => {
+    const client = createClient({
+      graphqlError: new Error("GitHub GraphQL failed: unexpected"),
+    });
+
+    await expect(
+      publishStageResultComment({
+        client,
+        context: context([priorReviewFinding()]),
+        logger: createLogger(),
+        parsedOutput: { ...output(), next_state: "review-passed", stage: "review-matrix" },
+        runner: runner(),
+      }),
+    ).rejects.toThrow("GitHub GraphQL failed: unexpected");
+  });
+});
+
 describe("pull request review publishing thread ownership", () => {
   it("does not reconcile review threads authored by someone else", async () => {
     const client = createClient();
@@ -310,7 +354,10 @@ function runner() {
 function createClient(options = {}) {
   return {
     apiBaseUrl: "https://api.github.test",
-    graphql: vi.fn(async () => ({})),
+    graphql: vi.fn(async () => {
+      if (options.graphqlError) throw options.graphqlError;
+      return {};
+    }),
     request: vi.fn(async (request) => {
       if (request.path !== "/user") return {};
       if (options.userLookupError) throw new Error("Resource not accessible by integration");

--- a/tests/run-action.test.mjs
+++ b/tests/run-action.test.mjs
@@ -36,6 +36,7 @@ describe("GitVibe action launcher", () => {
         env: {
           ...baseEnv,
           GITHUB_OUTPUT: "/tmp/output",
+          GITHUB_RUN_ATTEMPT: "3",
           GITHUB_RUN_ID: "99",
           GITHUB_SERVER_URL: "https://github.enterprise.test",
           GITVIBE_DRY_RUN: "true",
@@ -71,6 +72,7 @@ describe("GitVibe action launcher", () => {
         stageTimeoutMinutes: 34,
         validationRepairAttempts: 3,
         validationRepairMaxTurns: 45,
+        workflowRunAttempt: "3",
         workflowRunUrl: "https://github.enterprise.test/example/repo/actions/runs/99",
       }),
     );

--- a/tests/safety-gate.test.mjs
+++ b/tests/safety-gate.test.mjs
@@ -251,6 +251,35 @@ describe("prompt-injection safety gate extra sources", () => {
     expect(gate).toMatchObject({ allowed: false, severity: "high" });
     expect(gate.findings.join("\n")).toContain("validation repair stdout");
   });
+
+  it("includes a bounded matched excerpt for matrix member safety findings", () => {
+    const gate = safetyGateForStage({
+      config: {},
+      context: context({ comment: "" }),
+      extraSources: [
+        {
+          label: "matrix member result 2",
+          text: [
+            "`accepted_risk.skip` event with reason `workflow-run-attempt-changed`.",
+            "- **SHA validation** ensures the rerun points at the current PR head.",
+          ].join("\n"),
+        },
+      ],
+      stage: "review-matrix",
+    });
+    const output = safetyBlockedOutput({
+      context: context({ comment: "" }),
+      gate,
+      runner: runner("review-matrix"),
+    });
+
+    expect(gate).toMatchObject({ allowed: false, severity: "high" });
+    expect(gate.findings.join("\n")).toContain("matrix member result 2");
+    expect(gate.findings.join("\n")).toContain("matched excerpt");
+    expect(gate.findings.join("\n")).toContain("'accepted_risk.skip'");
+    expect(gate.findings.join("\n")).toContain("SHA validation");
+    expect(output.comment_body).toContain("matched excerpt");
+  });
 });
 
 describe("prompt-injection safety gate direct categories", () => {

--- a/tests/security-review-action.test.mjs
+++ b/tests/security-review-action.test.mjs
@@ -27,6 +27,7 @@ describe("GitVibe security review action", () => {
         env: {
           ...baseEnv,
           GITHUB_OUTPUT: "/tmp/output",
+          GITHUB_RUN_ATTEMPT: "3",
           GITHUB_RUN_ID: "99",
           GITHUB_SERVER_URL: "https://github.enterprise.test",
           GITVIBE_DRY_RUN: "true",
@@ -59,6 +60,7 @@ describe("GitVibe security review action", () => {
         },
         stage: "investigate",
         stageTimeoutMinutes: 7,
+        workflowRunAttempt: "3",
         workflowRunUrl: "https://github.enterprise.test/example/repo/actions/runs/99",
       }),
     );

--- a/tests/server-accept-risk-labels.test.mjs
+++ b/tests/server-accept-risk-labels.test.mjs
@@ -24,6 +24,7 @@ describe("GitVibe app server accept-risk labels", () => {
         }),
       ],
       permission: { role_name: "maintain" },
+      workflowRun: workflowRun(".github/workflows/develop.yml@main"),
     });
 
     await createApp({ client }).handleWebhook("issues", {
@@ -34,17 +35,14 @@ describe("GitVibe app server accept-risk labels", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({
-        inputs: { "issue-number": "9" },
-        ref: "main",
-      }),
-    ]);
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     const updatedResult = requestBodies(client, "PATCH", "/issues/comments/100").at(-1).body;
     expect(updatedResult).toContain("### Accepted Risk");
     expect(updatedResult).toContain("git-vibe:accepted-risk-metadata");
-    expect(updatedResult).toContain("run=1");
-    expect(updatedResult).toContain("Accepted workflow run: `1`");
+    expect(updatedResult).toContain("run=88");
+    expect(updatedResult).toContain("run-attempt=2");
+    expect(updatedResult).toContain("Accepted workflow run: `88`");
     expect(updatedResult).toContain("Accepted stages: `implement`, `create-pr`");
     expect(updatedResult).toContain("Artifact title/body SHA");
     expect(requestPaths(client, "DELETE")).toContain(
@@ -55,18 +53,18 @@ describe("GitVibe app server accept-risk labels", () => {
     );
   });
 
-  it("removes accept-risk without writing metadata when dispatch returns no run id", async () => {
+  it("removes accept-risk without writing metadata when no blocked workflow run is recorded", async () => {
     const client = createClient({
       comments: [
         stageResultComment({
           artifact: "issue",
           number: 9,
+          run: "",
           stage: "implement",
           submittedAt: "2026-01-02T00:00:00Z",
         }),
       ],
       permission: { role_name: "maintain" },
-      workflowDispatchResponse: { ref: "main" },
     });
 
     await createApp({ client }).handleWebhook("issues", {
@@ -77,30 +75,23 @@ describe("GitVibe app server accept-risk labels", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({
-        inputs: { "issue-number": "9" },
-      }),
-    ]);
+    expect(workflowDispatches(client)).toEqual([]);
     expect(requestBodies(client, "PATCH", "/issues/comments/100")).toEqual([]);
     expect(requestPaths(client, "DELETE")).toContain(
       "/repos/example/repo/issues/9/labels/git-vibe%3Aaccept-risk",
     );
     expect(requestBodies(client, "POST", "/issues/9/comments").at(-1).body).toContain(
-      "did not return a workflow run id",
+      "could not safely rerun",
     );
   });
 });
 
 describe("GitVibe app server accept-risk run id binding", () => {
-  it("binds accepted risk from workflow html_url when workflow_run_id is absent", async () => {
+  it("binds accepted risk to the trusted blocked run and next attempt", async () => {
     const client = createClient({
       comments: [stageResultComment({ artifact: "issue", number: 9, stage: "implement" })],
       permission: { role_name: "maintain" },
-      workflowDispatchResponse: {
-        html_url: "https://github.com/example/repo/actions/runs/42",
-        ref: "main",
-      },
+      workflowRun: workflowRun(".github/workflows/develop.yml@main", { run_attempt: 4 }),
     });
 
     await createApp({ client }).handleWebhook("issues", {
@@ -112,18 +103,17 @@ describe("GitVibe app server accept-risk run id binding", () => {
     });
 
     const updatedResult = requestBodies(client, "PATCH", "/issues/comments/100").at(-1).body;
-    expect(updatedResult).toContain("run=42");
-    expect(updatedResult).toContain("Accepted workflow run: `42`");
+    expect(updatedResult).toContain("run=88");
+    expect(updatedResult).toContain("run-attempt=5");
+    expect(updatedResult).toContain("Accepted workflow run: `88`");
+    expect(updatedResult).toContain("Accepted workflow attempt: `5`");
   });
 
-  it("binds accepted risk from workflow run_url when html_url is absent", async () => {
+  it("posts the rerun workflow URL from the blocked run details", async () => {
     const client = createClient({
       comments: [stageResultComment({ artifact: "issue", number: 9, stage: "implement" })],
       permission: { role_name: "maintain" },
-      workflowDispatchResponse: {
-        ref: "main",
-        run_url: "https://api.github.com/repos/example/repo/actions/runs/43",
-      },
+      workflowRun: workflowRun(".github/workflows/develop.yml@main"),
     });
 
     await createApp({ client }).handleWebhook("issues", {
@@ -134,19 +124,18 @@ describe("GitVibe app server accept-risk run id binding", () => {
       sender: { login: "maintainer" },
     });
 
-    const updatedResult = requestBodies(client, "PATCH", "/issues/comments/100").at(-1).body;
-    expect(updatedResult).toContain("run=43");
-    expect(updatedResult).toContain("Accepted workflow run: `43`");
+    expect(requestBodies(client, "POST", "/issues/9/comments").at(-1).body).toContain(
+      "Workflow run: https://github.com/example/repo/actions/runs/88",
+    );
   });
 });
 
-describe("GitVibe app server accept-risk dispatch failures", () => {
-  it("removes accept-risk without writing metadata when dispatch fails", async () => {
+describe("GitVibe app server accept-risk rerun-unavailable cleanup", () => {
+  it("removes accept-risk without writing metadata when the blocked run cannot be fetched", async () => {
     const client = createClient({
       comments: [stageResultComment({ artifact: "issue", number: 9, stage: "implement" })],
       permission: { role_name: "maintain" },
-      workflowDispatchError: new Error("dispatch unavailable"),
-      workflowDispatchErrorCount: 1,
+      workflowRunError: new Error("GitHub API GET /actions/runs/88 failed: 404 {}"),
     });
     const log = vi.fn();
 
@@ -159,13 +148,14 @@ describe("GitVibe app server accept-risk dispatch failures", () => {
     });
 
     expect(requestBodies(client, "PATCH", "/issues/comments/100")).toEqual([]);
+    expect(workflowDispatches(client)).toEqual([]);
     expect(requestPaths(client, "DELETE")).toContain(
       "/repos/example/repo/issues/9/labels/git-vibe%3Aaccept-risk",
     );
     expect(requestBodies(client, "POST", "/issues/9/comments").at(-1).body).toContain(
-      "could not queue a run-bound accepted-risk workflow",
+      "could not safely rerun",
     );
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("dispatch unavailable"));
+    expect(log).toHaveBeenCalledWith("accepted-risk rerun skipped: workflow run 88 is unavailable");
   });
 });
 
@@ -194,16 +184,13 @@ describe("GitVibe app server accept-risk pull request reviews", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({
-        inputs: { "pr-number": "12" },
-      }),
-    ]);
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body).toContain(
       "### Accepted Risk",
     );
     expect(requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body).toContain(
-      "Accepted workflow run: `1`",
+      "Accepted workflow run: `88`",
     );
     expect(requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body).toContain(
       "Pull request head SHA: `head-sha`",
@@ -247,6 +234,10 @@ describe("GitVibe app server accept-risk pull request review pagination", () => 
           }),
         ],
       ],
+      workflowRun: workflowRun(".github/workflows/address-feedback.yml@dev", {
+        head_branch: "dev",
+        head_sha: "head-sha",
+      }),
     });
 
     await createApp({ client }).handleWebhook("pull_request", {
@@ -257,7 +248,8 @@ describe("GitVibe app server accept-risk pull request review pagination", () => 
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)[0].inputs).toEqual({ "pr-number": "12" });
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body).toContain(
       "Accepted stages: `investigate`, `address-pr-feedback`",
     );
@@ -311,6 +303,7 @@ describe("GitVibe app server accept-risk label result selection", () => {
         }),
       ],
       permission: { role_name: "maintain" },
+      workflowRun: workflowRun(".github/workflows/develop.yml@main"),
     });
 
     await createApp({ client }).handleWebhook("issues", {
@@ -321,11 +314,8 @@ describe("GitVibe app server accept-risk label result selection", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({
-        inputs: { "issue-number": "9" },
-      }),
-    ]);
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(requestBodies(client, "PATCH", "/issues/comments/100").at(-1).body).toContain(
       "Accepted stages: `implement`, `create-pr`",
     );
@@ -399,6 +389,7 @@ describe("GitVibe app server accept-risk label stage routing", () => {
     const client = createClient({
       comments: [stageResultComment({ artifact: "issue", number: 9, stage: "investigate" })],
       permission: { role_name: "maintain" },
+      workflowRun: workflowRun(".github/workflows/investigate.yml@main"),
     });
 
     await createApp({ client }).handleWebhook("issues", {
@@ -409,10 +400,8 @@ describe("GitVibe app server accept-risk label stage routing", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(requestPaths(client, "POST")).toContain(
-      "/repos/example/repo/actions/workflows/investigate.yml/dispatches",
-    );
-    expect(workflowDispatches(client)[0].inputs).toEqual({ "issue-number": "9" });
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(requestBodies(client, "PATCH", "/issues/comments/100").at(-1).body).toContain(
       "Accepted stages: `investigate`",
     );
@@ -481,6 +470,10 @@ describe("GitVibe app server accept-risk pull request labels", () => {
       ],
       permission: { role_name: "maintain" },
       pullRequestHeadSha: "lookup-sha",
+      workflowRun: workflowRun(".github/workflows/address-feedback.yml@dev", {
+        head_branch: "dev",
+        head_sha: "lookup-sha",
+      }),
     });
 
     await createApp({ client }).handleWebhook("pull_request", {
@@ -491,11 +484,8 @@ describe("GitVibe app server accept-risk pull request labels", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({
-        inputs: { "pr-number": "12" },
-      }),
-    ]);
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(requestBodies(client, "PATCH", "/issues/comments/100").at(-1).body).toContain(
       "Pull request head SHA: `lookup-sha`",
     );
@@ -517,6 +507,7 @@ describe("GitVibe app server accept-risk label validation", () => {
         },
       ],
       permission: { role_name: "maintain" },
+      workflowRun: workflowRun(".github/workflows/validate.yml@main"),
     });
 
     await createApp({ client }).handleWebhook("discussion", {
@@ -527,11 +518,8 @@ describe("GitVibe app server accept-risk label validation", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({
-        inputs: { "discussion-number": "5" },
-      }),
-    ]);
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(discussionUpdateBodies(client).at(-1)).toContain("Accepted stages: `validate`");
   });
 
@@ -548,6 +536,7 @@ describe("GitVibe app server accept-risk label validation", () => {
         },
       ],
       permission: { role_name: "maintain" },
+      workflowRun: workflowRun(".github/workflows/materialize.yml@main"),
     });
 
     await createApp({ client }).handleWebhook("discussion", {
@@ -558,11 +547,8 @@ describe("GitVibe app server accept-risk label validation", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({
-        inputs: { "discussion-number": "5" },
-      }),
-    ]);
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(discussionUpdateBodies(client).at(-1)).toContain("Accepted stages: `materialize`");
   });
 });
@@ -651,13 +637,14 @@ describe("GitVibe app server accept-risk label no-op cleanup", () => {
 function stageResultComment({
   artifact,
   number,
+  run = "88",
   stage,
   status = "blocked",
   submittedAt = "2026-01-01T00:00:00Z",
 }) {
   return {
     author_association: "OWNER",
-    body: stageResultBody({ artifact, number, stage, status }),
+    body: stageResultBody({ artifact, number, run, stage, status }),
     created_at: submittedAt,
     id: 100,
     user: { login: "maintainer" },
@@ -668,22 +655,24 @@ function stageResultReview({
   artifact,
   authorAssociation = "OWNER",
   number,
+  run = "88",
   stage,
   submittedAt = "2026-01-01T00:00:00Z",
   user = "maintainer",
 }) {
   return {
     author_association: authorAssociation,
-    body: stageResultBody({ artifact, number, stage }),
+    body: stageResultBody({ artifact, number, run, stage }),
     id: 200,
     submitted_at: submittedAt,
     user: { login: user },
   };
 }
 
-function stageResultBody({ artifact, number, stage, status = "blocked" }) {
+function stageResultBody({ artifact, number, run = "88", stage, status = "blocked" }) {
+  const runAttribute = run ? ` run=${run}` : "";
   return [
-    `<!-- git-vibe:stage-result stage=${stage} artifact=${artifact} number=${number} -->`,
+    `<!-- git-vibe:stage-result stage=${stage} artifact=${artifact} number=${number}${runAttribute} -->`,
     "## GitVibe Result",
     "",
     `**Status:** \`${status}\``,
@@ -691,6 +680,17 @@ function stageResultBody({ artifact, number, stage, status = "blocked" }) {
     "",
     "GitVibe paused this run for maintainer review.",
   ].join("\n");
+}
+
+function workflowRun(path, overrides = {}) {
+  return {
+    head_branch: "main",
+    html_url: "https://github.com/example/repo/actions/runs/88",
+    path,
+    run_attempt: 1,
+    url: "https://api.github.com/repos/example/repo/actions/runs/88",
+    ...overrides,
+  };
 }
 
 function discussionUpdateBodies(client) {

--- a/tests/server-accept-risk-rerun.test.mjs
+++ b/tests/server-accept-risk-rerun.test.mjs
@@ -43,7 +43,34 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
     });
   });
 
-  it("dispatches review when the blocked result came from a different workflow", async () => {
+  it("reruns blocked automatic pull request review wrapper workflows", async () => {
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRun: {
+        head_branch: "dev",
+        head_sha: "head-sha",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/automatic-pr-review.yml@refs/heads/dev",
+        run_attempt: 1,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      },
+    });
+
+    await createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
+
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expectMetadataUpdateBeforeRerun(client);
+    expect(workflowDispatches(client)).toEqual([]);
+    const updatedResult = requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body;
+    expect(updatedResult).toContain("run=88");
+    expect(updatedResult).toContain("run-attempt=2");
+  });
+});
+
+describe("GitVibe app server accept-risk pull request rerun unavailable", () => {
+  it("removes accept-risk when the blocked result came from a different workflow", async () => {
     const log = vi.fn();
     const client = createClient({
       permission: { role_name: "maintain" },
@@ -60,15 +87,20 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
     await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
 
     expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({ inputs: { "pr-number": "12" } }),
-    ]);
+    expect(workflowDispatches(client)).toEqual([]);
+    expect(requestBodies(client, "PUT", "/pulls/12/reviews/200")).toEqual([]);
+    expect(requestPaths(client, "DELETE")).toContain(
+      "/repos/example/repo/issues/12/labels/git-vibe%3Aaccept-risk",
+    );
+    expect(requestBodies(client, "POST", "/issues/12/comments").at(-1).body).toContain(
+      "could not safely rerun",
+    );
     expect(log).toHaveBeenCalledWith(
       "accepted-risk rerun skipped: workflow run 88 does not match review.yml",
     );
   });
 
-  it("dispatches review when the prior workflow run is unavailable", async () => {
+  it("removes accept-risk when the prior workflow run is unavailable", async () => {
     const log = vi.fn();
     const client = createClient({
       permission: { role_name: "maintain" },
@@ -80,15 +112,20 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
     await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
 
     expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({ inputs: { "pr-number": "12" } }),
-    ]);
+    expect(workflowDispatches(client)).toEqual([]);
+    expect(requestBodies(client, "PUT", "/pulls/12/reviews/200")).toEqual([]);
+    expect(requestPaths(client, "DELETE")).toContain(
+      "/repos/example/repo/issues/12/labels/git-vibe%3Aaccept-risk",
+    );
+    expect(requestBodies(client, "POST", "/issues/12/comments").at(-1).body).toContain(
+      "could not safely rerun",
+    );
     expect(log).toHaveBeenCalledWith("accepted-risk rerun skipped: workflow run 88 is unavailable");
   });
 });
 
 describe("GitVibe app server accept-risk pull request rerun SHA checks", () => {
-  it("dispatches review when the prior workflow run head SHA differs", async () => {
+  it("removes accept-risk when the prior workflow run head SHA differs", async () => {
     const log = vi.fn();
     const client = createClient({
       permission: { role_name: "maintain" },
@@ -106,9 +143,14 @@ describe("GitVibe app server accept-risk pull request rerun SHA checks", () => {
     await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
 
     expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({ inputs: { "pr-number": "12" } }),
-    ]);
+    expect(workflowDispatches(client)).toEqual([]);
+    expect(requestBodies(client, "PUT", "/pulls/12/reviews/200")).toEqual([]);
+    expect(requestPaths(client, "DELETE")).toContain(
+      "/repos/example/repo/issues/12/labels/git-vibe%3Aaccept-risk",
+    );
+    expect(requestBodies(client, "POST", "/issues/12/comments").at(-1).body).toContain(
+      "could not safely rerun",
+    );
     expect(log).toHaveBeenCalledWith(
       "accepted-risk rerun skipped: workflow run 88 head SHA does not match",
     );

--- a/tests/server-accept-risk-rerun.test.mjs
+++ b/tests/server-accept-risk-rerun.test.mjs
@@ -1,0 +1,154 @@
+// @ts-nocheck
+import { describe, expect, it, vi } from "vitest";
+import { gitVibeLabels } from "../src/shared/labels.ts";
+import {
+  createApp,
+  createClient,
+  repositoryPayload,
+  requestBodies,
+  requestPaths,
+  workflowDispatches,
+} from "./support/server-app.mjs";
+
+describe("GitVibe app server accept-risk pull request reruns", () => {
+  it("reruns blocked pull request review workflows and binds the next run attempt", async () => {
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRun: {
+        head_branch: "dev",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/review.yml@dev",
+        run_attempt: 2,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      },
+    });
+
+    await createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
+
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
+    const updatedResult = requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body;
+    expect(updatedResult).toContain("run=88");
+    expect(updatedResult).toContain("run-attempt=3");
+    expect(updatedResult).toContain("Accepted workflow attempt: `3`");
+    expect(requestBodies(client, "POST", "/issues/12/comments").at(-1).body).toContain(
+      "Workflow run: https://github.com/example/repo/actions/runs/88",
+    );
+    expect(requestBodies(client, "POST", "/issues/12/labels")).toContainEqual({
+      labels: ["gvi:reviewing"],
+    });
+  });
+
+  it("dispatches review when the blocked result came from a different workflow", async () => {
+    const log = vi.fn();
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRun: {
+        head_branch: "dev",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/develop.yml@dev",
+        run_attempt: 2,
+      },
+    });
+
+    await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
+
+    expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([
+      expect.objectContaining({ inputs: { "pr-number": "12" } }),
+    ]);
+    expect(log).toHaveBeenCalledWith(
+      "accepted-risk rerun skipped: workflow run 88 does not match review.yml",
+    );
+  });
+
+  it("dispatches review when the prior workflow run is unavailable", async () => {
+    const log = vi.fn();
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRunError: new Error("GitHub API GET /actions/runs/88 failed: 404 {}"),
+    });
+
+    await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
+
+    expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([
+      expect.objectContaining({ inputs: { "pr-number": "12" } }),
+    ]);
+    expect(log).toHaveBeenCalledWith("accepted-risk rerun skipped: workflow run 88 is unavailable");
+  });
+});
+
+describe("GitVibe app server accept-risk pull request rerun failures", () => {
+  it("does not dispatch review when workflow run lookup fails unexpectedly", async () => {
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "404" })],
+      workflowRunError: new Error("GitHub API GET /actions/runs/404 failed: 403 {}"),
+    });
+
+    await expect(
+      createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload()),
+    ).rejects.toThrow("403");
+
+    expect(requestPaths(client, "POST")).not.toContain(
+      "/repos/example/repo/actions/runs/404/rerun",
+    );
+    expect(workflowDispatches(client)).toEqual([]);
+  });
+
+  it("does not dispatch review when rerun request fails", async () => {
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRerunError: new Error("GitHub API POST /actions/runs/88/rerun failed: 403 {}"),
+    });
+
+    await expect(
+      createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload()),
+    ).rejects.toThrow("403");
+
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
+  });
+});
+
+function acceptRiskPullRequestPayload() {
+  return {
+    action: "labeled",
+    label: { name: gitVibeLabels.acceptRisk.name },
+    pull_request: { head: { sha: "head-sha" }, number: 12 },
+    repository: repositoryPayload(),
+    sender: { login: "maintainer" },
+  };
+}
+
+function stageResultReview({ run }) {
+  return {
+    author_association: "OWNER",
+    body: stageResultBody({ run }),
+    id: 200,
+    submitted_at: "2026-01-01T00:00:00Z",
+    user: { login: "maintainer" },
+  };
+}
+
+function stageResultBody({ run }) {
+  return [
+    `<!-- git-vibe:stage-result stage=review-matrix artifact=pull-request number=12 run=${run} -->`,
+    "## GitVibe Result",
+    "",
+    "**Status:** `blocked`",
+    "**Next state:** `blocked`",
+    "",
+    "GitVibe paused this run for maintainer review.",
+  ].join("\n");
+}

--- a/tests/server-accept-risk-rerun.test.mjs
+++ b/tests/server-accept-risk-rerun.test.mjs
@@ -18,6 +18,7 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
       pullRequestReviews: [stageResultReview({ run: "88" })],
       workflowRun: {
         head_branch: "dev",
+        head_sha: "head-sha",
         html_url: "https://github.com/example/repo/actions/runs/88",
         path: ".github/workflows/review.yml@dev",
         run_attempt: 2,
@@ -28,6 +29,7 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
     await createApp({ client }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
 
     expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expectMetadataUpdateBeforeRerun(client);
     expect(workflowDispatches(client)).toEqual([]);
     const updatedResult = requestBodies(client, "PUT", "/pulls/12/reviews/200").at(-1).body;
     expect(updatedResult).toContain("run=88");
@@ -85,6 +87,34 @@ describe("GitVibe app server accept-risk pull request reruns", () => {
   });
 });
 
+describe("GitVibe app server accept-risk pull request rerun SHA checks", () => {
+  it("dispatches review when the prior workflow run head SHA differs", async () => {
+    const log = vi.fn();
+    const client = createClient({
+      permission: { role_name: "maintain" },
+      pullRequestHeadSha: "head-sha",
+      pullRequestReviews: [stageResultReview({ run: "88" })],
+      workflowRun: {
+        head_branch: "dev",
+        head_sha: "old-sha",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/review.yml@dev",
+        run_attempt: 2,
+      },
+    });
+
+    await createApp({ client, log }).handleWebhook("pull_request", acceptRiskPullRequestPayload());
+
+    expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([
+      expect.objectContaining({ inputs: { "pr-number": "12" } }),
+    ]);
+    expect(log).toHaveBeenCalledWith(
+      "accepted-risk rerun skipped: workflow run 88 head SHA does not match",
+    );
+  });
+});
+
 describe("GitVibe app server accept-risk pull request rerun failures", () => {
   it("does not dispatch review when workflow run lookup fails unexpectedly", async () => {
     const client = createClient({
@@ -129,6 +159,19 @@ function acceptRiskPullRequestPayload() {
     repository: repositoryPayload(),
     sender: { login: "maintainer" },
   };
+}
+
+function expectMetadataUpdateBeforeRerun(client) {
+  const calls = client.request.mock.calls.map(([request]) => request);
+  const metadataIndex = calls.findIndex(
+    (request) => request.method === "PUT" && request.path.includes("/pulls/12/reviews/200"),
+  );
+  const rerunIndex = calls.findIndex(
+    (request) => request.method === "POST" && request.path.endsWith("/actions/runs/88/rerun"),
+  );
+  expect(metadataIndex).toBeGreaterThan(-1);
+  expect(rerunIndex).toBeGreaterThan(-1);
+  expect(metadataIndex).toBeLessThan(rerunIndex);
 }
 
 function stageResultReview({ run }) {

--- a/tests/server-accept-risk-run-binding.test.mjs
+++ b/tests/server-accept-risk-run-binding.test.mjs
@@ -15,6 +15,13 @@ describe("GitVibe app server accept-risk run-bound metadata sources", () => {
     const client = createClient({
       comments: [stageResultComment({ stage: "validate" })],
       permission: { role_name: "maintain" },
+      workflowRun: {
+        head_branch: "main",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/validate.yml@main",
+        run_attempt: 1,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      },
     });
 
     await createApp({ client }).handleWebhook("issues", {
@@ -25,15 +32,14 @@ describe("GitVibe app server accept-risk run-bound metadata sources", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(requestPaths(client, "POST")).toContain(
-      "/repos/example/repo/actions/workflows/validate.yml/dispatches",
-    );
-    expect(workflowDispatches(client)[0].inputs).toEqual({ "issue-number": "9" });
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
   });
 
   it("uses pull request payload title and body when binding accepted risk", async () => {
     const client = createClient({
       permission: { role_name: "maintain" },
+      pullRequestHeadSha: "payload-sha",
       pullRequestReviews: [stageResultReview()],
     });
 
@@ -60,6 +66,13 @@ describe("GitVibe app server accept-risk run-bound metadata sources", () => {
     const client = createClient({
       discussionComments: [discussionStageResultComment()],
       permission: { role_name: "maintain" },
+      workflowRun: {
+        head_branch: "main",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/validate.yml@main",
+        run_attempt: 1,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      },
     });
 
     await createApp({ client }).handleWebhook("discussion", {
@@ -75,7 +88,8 @@ describe("GitVibe app server accept-risk run-bound metadata sources", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)[0].inputs).toEqual({ "discussion-number": "5" });
+    expect(requestPaths(client, "POST")).toContain("/repos/example/repo/actions/runs/88/rerun");
+    expect(workflowDispatches(client)).toEqual([]);
     expect(discussionUpdateBodies(client).at(-1)).toContain("Accepted stages: `validate`");
   });
 });
@@ -86,6 +100,13 @@ describe("GitVibe app server accept-risk run-bound metadata failures", () => {
       comments: [stageResultComment()],
       issuePatchError: new Error("patch unavailable"),
       permission: { role_name: "maintain" },
+      workflowRun: {
+        head_branch: "main",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/develop.yml@main",
+        run_attempt: 1,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      },
     });
     const log = vi.fn();
 
@@ -97,9 +118,8 @@ describe("GitVibe app server accept-risk run-bound metadata failures", () => {
       sender: { login: "maintainer" },
     });
 
-    expect(workflowDispatches(client)).toEqual([
-      expect.objectContaining({ inputs: { "issue-number": "9" } }),
-    ]);
+    expect(workflowDispatches(client)).toEqual([]);
+    expect(requestPaths(client, "POST")).not.toContain("/repos/example/repo/actions/runs/88/rerun");
     expect(requestPaths(client, "DELETE")).toContain(
       "/repos/example/repo/issues/9/labels/git-vibe%3Aaccept-risk",
     );
@@ -143,7 +163,7 @@ function discussionStageResultComment() {
 
 function stageResultBody({ artifact, number, stage }) {
   return [
-    `<!-- git-vibe:stage-result stage=${stage} artifact=${artifact} number=${number} -->`,
+    `<!-- git-vibe:stage-result stage=${stage} artifact=${artifact} number=${number} run=88 -->`,
     "## GitVibe Result",
     "",
     "**Status:** `blocked`",

--- a/tests/support/server-app.mjs
+++ b/tests/support/server-app.mjs
@@ -118,6 +118,7 @@ function requestResponseFor(request, options) {
     return (
       options.workflowRun || {
         head_branch: "main",
+        head_sha: options.workflowRunHeadSha || options.pullRequestHeadSha || "head-sha",
         html_url: "https://github.com/example/repo/actions/runs/88",
         path: ".github/workflows/review.yml@main",
         run_attempt: 1,

--- a/tests/support/server-app.mjs
+++ b/tests/support/server-app.mjs
@@ -113,6 +113,22 @@ function requestResponseFor(request, options) {
     }
     throw new Error("GitHub API GET actions variable failed: 404");
   }
+  if (request.method === "GET" && /\/actions\/runs\/\d+$/.test(request.path)) {
+    if (options.workflowRunError) throw options.workflowRunError;
+    return (
+      options.workflowRun || {
+        head_branch: "main",
+        html_url: "https://github.com/example/repo/actions/runs/88",
+        path: ".github/workflows/review.yml@main",
+        run_attempt: 1,
+        url: "https://api.github.com/repos/example/repo/actions/runs/88",
+      }
+    );
+  }
+  if (request.method === "POST" && /\/actions\/runs\/\d+\/rerun$/.test(request.path)) {
+    if (options.workflowRerunError) throw options.workflowRerunError;
+    return options.workflowRerunResponse || {};
+  }
   if (request.method === "GET" && request.path === "/repos/example/repo") {
     return { default_branch: options.defaultBranch || "main" };
   }


### PR DESCRIPTION
## Summary
- Promote `dev` into `main`.
- Includes accepted-risk PR rerun handling from #55, including rerun attempt binding and explicit failure handling for rerun API errors.

## Branch Compare
- Base: `main`
- Head: `dev`
- Ahead by: 1 commit
- Note: `dev` is behind `main` by merge commits from prior promotions, per GitHub compare.

## Validation
- Not run for this PR creation step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trigger accepted-risk reruns for eligible blocked reviews via workflow-run rerun, with attempt-aware updates to the PR review/comment metadata.
  * Render “Accepted workflow attempt” plus `run-attempt` in accepted-risk metadata and audit marker comments.
* **Bug Fixes**
  * Prevent accepted-risk from applying when the recorded run attempt doesn’t match the current workflow run attempt; skip reruns when rerun safety checks fail.
  * Safety findings now include bounded matched excerpts.
  * PR review thread publishing now skips GitHub “FORBIDDEN” resolution failures.
* **Tests**
  * Expanded coverage for rerun flows, attempt-bound binding/audit behavior, run-attempt forwarding, and excerpted safety findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->