### PR TITLE
Prepare v4.1.1 security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ Profiles may opt into shared repository guidance with
 `ai.profiles.<name>.context.files`. Listed files are appended to the rendered
 system prompt for that profile across `ai-sdk-agentool`, `cli-codex`, and
 `cli-claude-code`; GitVibe never auto-loads `AGENTS.md` or `CLAUDE.md`.
+AI SDK provider HTTP responses are capped at 64 MiB by default. Set
+`ai.budgets.provider_response_max_bytes` to a larger positive integer only when
+a trusted provider needs larger JSON responses.
 
 Stages may also opt into MCP servers through `ai.stages.<stage>.mcp`. Each
 server can expose a flat `tools` list to the model. For advanced deterministic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-vibe/app",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": false,
   "type": "module",
   "packageManager": "pnpm@10.33.3",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "*.{js,mjs,ts}": "eslint"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.74",
-    "@ai-sdk/mcp": "^1.0.46",
-    "@ai-sdk/openai": "^3.0.60",
+    "@ai-sdk/anthropic": "^3.0.84",
+    "@ai-sdk/mcp": "^1.0.50",
+    "@ai-sdk/openai": "^3.0.71",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "agentool": "^1.5.2",
-    "ai": "^6.0.175",
+    "ai": "^6.0.205",
     "jose": "^6.2.3",
     "libsodium-wrappers": "^0.8.4",
     "yaml": "^2.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,23 +12,23 @@ importers:
   .:
     dependencies:
       "@ai-sdk/anthropic":
-        specifier: ^3.0.74
-        version: 3.0.74(zod@4.4.3)
+        specifier: ^3.0.84
+        version: 3.0.84(zod@4.4.3)
       "@ai-sdk/mcp":
-        specifier: ^1.0.46
-        version: 1.0.46(zod@4.4.3)
+        specifier: ^1.0.50
+        version: 1.0.50(zod@4.4.3)
       "@ai-sdk/openai":
-        specifier: ^3.0.60
-        version: 3.0.60(zod@4.4.3)
+        specifier: ^3.0.71
+        version: 3.0.71(zod@4.4.3)
       "@modelcontextprotocol/sdk":
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
       agentool:
         specifier: ^1.5.2
-        version: 1.5.2(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+        version: 1.5.2(ai@6.0.205(zod@4.4.3))(zod@4.4.3)
       ai:
-        specifier: ^6.0.175
-        version: 6.0.175(zod@4.4.3)
+        specifier: ^6.0.205
+        version: 6.0.205(zod@4.4.3)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -80,7 +80,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4))
 
   packages/git-vibe-setup:
     devDependencies:
@@ -92,58 +92,49 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4))
 
 packages:
-  "@ai-sdk/anthropic@3.0.74":
+  "@ai-sdk/anthropic@3.0.84":
     resolution:
       {
-        integrity: sha512-Xew9rfz9WWhDSyF8rNhjT/XWOWelNfJrMlmG0Ahw210hStisRpQZ1s+7VeI9JTJOZ5y5tXqBi5kfPwYnCfyRTA==,
+        integrity: sha512-BIDaHmCHs6Sr5VUsEkTbbVlAN4GWjg97X9x/IfXyviLtzsXvffui9XIcZugkAi1Ri6FnvI5T5qDGh5YLnSuzRg==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/gateway@3.0.110":
+  "@ai-sdk/gateway@3.0.131":
     resolution:
       {
-        integrity: sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg==,
+        integrity: sha512-CnjOZdywQaUnCyZ0N5wVNm7Sm63+NeHDVZQJKFX2IDq+t03SLwiiuoi3ILTLPlM+YSOhkQ/pvIDoR4qa98Zp5A==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/mcp@1.0.46":
+  "@ai-sdk/mcp@1.0.50":
     resolution:
       {
-        integrity: sha512-owU0wAP87KzsTzr+2JE9sT9lpsCWKg8ZwHhce/KQmD9D/kbhe69sUZ+lsFF5MoGvV/ZzMujrhAvC1MgmufwMeQ==,
+        integrity: sha512-iLqDZ62ezEjBhTJgiAQ4D2tHG1q7INVhPx0uOPnxJTxxqVUzN4KqeWAd6j5hYNhsPqC7TPGRQHQqAa1Z/lu2jg==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/openai@3.0.60":
+  "@ai-sdk/openai@3.0.71":
     resolution:
       {
-        integrity: sha512-vZKqbDSCF1T65gDMG2ILJ2NAEpG45U2VtvEve1Fv/WRLu2i5TPUqxjlGKm+5a7Dd57Yr6CGePxrJhsQJC8LJ3A==,
+        integrity: sha512-j6eBAa5oHFZ4U5CxpIV3T4zXNM/BviodNCZCL1qHkA4aqkwK9iQ18TWYz2DZcXpw4BO5pikKzqpXORxb1EnZGA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/provider-utils@4.0.26":
+  "@ai-sdk/provider-utils@4.0.29":
     resolution:
       {
-        integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==,
-      }
-    engines: { node: ">=18" }
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  "@ai-sdk/provider-utils@4.0.27":
-    resolution:
-      {
-        integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==,
+        integrity: sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -584,19 +575,19 @@ packages:
       "@cfworker/json-schema":
         optional: true
 
-  "@napi-rs/wasm-runtime@1.1.4":
+  "@napi-rs/wasm-runtime@1.1.5":
     resolution:
       {
-        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
+        integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==,
       }
     peerDependencies:
       "@emnapi/core": ^1.7.1
       "@emnapi/runtime": ^1.7.1
 
-  "@opentelemetry/api@1.9.0":
+  "@opentelemetry/api@1.9.1":
     resolution:
       {
-        integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==,
+        integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==,
       }
     engines: { node: ">=8.0.0" }
 
@@ -998,10 +989,10 @@ packages:
       ai: ">=5.0.17"
       zod: ">=3.23.0"
 
-  ai@6.0.175:
+  ai@6.0.205:
     resolution:
       {
-        integrity: sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA==,
+        integrity: sha512-F4akEGF41UdgJO3L4v+D5noVD1/czhJy6x0k9R/i1EXfxqrkBh/PdYSgRSLPiGFvrw76dzI8h4w3NYmLrTb8dw==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -1423,6 +1414,13 @@ packages:
     resolution:
       {
         integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  eventsource-parser@3.1.0:
+    resolution:
+      {
+        integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==,
       }
     engines: { node: ">=18.0.0" }
 
@@ -2183,10 +2181,10 @@ packages:
       }
     engines: { node: ">=16.20.0" }
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     resolution:
       {
-        integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==,
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -2466,6 +2464,13 @@ packages:
       }
     engines: { node: ">=12.0.0" }
 
+  tinyglobby@0.2.17:
+    resolution:
+      {
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
+      }
+    engines: { node: ">=12.0.0" }
+
   tinyrainbow@3.1.0:
     resolution:
       {
@@ -2713,44 +2718,37 @@ packages:
       }
 
 snapshots:
-  "@ai-sdk/anthropic@3.0.74(zod@4.4.3)":
+  "@ai-sdk/anthropic@3.0.84(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 3.0.10
-      "@ai-sdk/provider-utils": 4.0.26(zod@4.4.3)
+      "@ai-sdk/provider-utils": 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
-  "@ai-sdk/gateway@3.0.110(zod@4.4.3)":
+  "@ai-sdk/gateway@3.0.131(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 3.0.10
-      "@ai-sdk/provider-utils": 4.0.26(zod@4.4.3)
+      "@ai-sdk/provider-utils": 4.0.29(zod@4.4.3)
       "@vercel/oidc": 3.2.0
       zod: 4.4.3
 
-  "@ai-sdk/mcp@1.0.46(zod@4.4.3)":
+  "@ai-sdk/mcp@1.0.50(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 3.0.10
-      "@ai-sdk/provider-utils": 4.0.27(zod@4.4.3)
+      "@ai-sdk/provider-utils": 4.0.29(zod@4.4.3)
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  "@ai-sdk/openai@3.0.60(zod@4.4.3)":
+  "@ai-sdk/openai@3.0.71(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 3.0.10
-      "@ai-sdk/provider-utils": 4.0.26(zod@4.4.3)
+      "@ai-sdk/provider-utils": 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
-  "@ai-sdk/provider-utils@4.0.26(zod@4.4.3)":
+  "@ai-sdk/provider-utils@4.0.29(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 3.0.10
       "@standard-schema/spec": 1.1.0
-      eventsource-parser: 3.0.8
-      zod: 4.4.3
-
-  "@ai-sdk/provider-utils@4.0.27(zod@4.4.3)":
-    dependencies:
-      "@ai-sdk/provider": 3.0.10
-      "@standard-schema/spec": 1.1.0
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
       zod: 4.4.3
 
   "@ai-sdk/provider@3.0.10":
@@ -2953,14 +2951,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+  "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
       "@emnapi/core": 1.10.0
       "@emnapi/runtime": 1.10.0
       "@tybys/wasm-util": 0.10.2
     optional: true
 
-  "@opentelemetry/api@1.9.0": {}
+  "@opentelemetry/api@1.9.1": {}
 
   "@oxc-project/types@0.127.0": {}
 
@@ -3004,7 +3002,7 @@ snapshots:
     dependencies:
       "@emnapi/core": 1.10.0
       "@emnapi/runtime": 1.10.0
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
@@ -3144,7 +3142,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4))
 
   "@vitest/expect@4.1.5":
     dependencies:
@@ -3200,20 +3198,20 @@ snapshots:
 
   adm-zip@0.5.17: {}
 
-  agentool@1.5.2(ai@6.0.175(zod@4.4.3))(zod@4.4.3):
+  agentool@1.5.2(ai@6.0.205(zod@4.4.3))(zod@4.4.3):
     dependencies:
-      ai: 6.0.175(zod@4.4.3)
+      ai: 6.0.205(zod@4.4.3)
       ajv: 8.20.0
       diff: 9.0.0
       turndown: 7.2.4
       zod: 4.4.3
 
-  ai@6.0.175(zod@4.4.3):
+  ai@6.0.205(zod@4.4.3):
     dependencies:
-      "@ai-sdk/gateway": 3.0.110(zod@4.4.3)
+      "@ai-sdk/gateway": 3.0.131(zod@4.4.3)
       "@ai-sdk/provider": 3.0.10
-      "@ai-sdk/provider-utils": 4.0.26(zod@4.4.3)
-      "@opentelemetry/api": 1.9.0
+      "@ai-sdk/provider-utils": 4.0.29(zod@4.4.3)
+      "@opentelemetry/api": 1.9.1
       zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -3468,6 +3466,8 @@ snapshots:
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.8: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -3864,7 +3864,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -4059,6 +4059,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
@@ -4100,16 +4105,16 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       "@types/node": 25.6.0
       esbuild: 0.28.0
       fsevents: 2.3.3
       yaml: 2.8.4
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4)):
     dependencies:
       "@vitest/expect": 4.1.5
       "@vitest/mocker": 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4))
@@ -4132,7 +4137,7 @@ snapshots:
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/api": 1.9.1
       "@types/node": 25.6.0
       "@vitest/coverage-v8": 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:

--- a/src/runner/ai-retry.ts
+++ b/src/runner/ai-retry.ts
@@ -3,16 +3,22 @@ import type { StageLogger } from "./logging.js";
 import { summarizeError } from "./logging.js";
 import type { GitVibeConfig } from "../shared/types.js";
 
+const DEFAULT_PROVIDER_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
+
 export function createRetryingFetch(options: {
   config: GitVibeConfig;
   logger?: StageLogger;
 }): typeof fetch {
   const maxRetries = aiRequestRetryAttemptsFor(options.config);
   const baseDelayMs = aiRequestRetryDelayMsFor(options.config);
+  const maxResponseBytes = aiProviderResponseMaxBytesFor(options.config);
   return async (input, init) => {
     for (let attempt = 0; ; attempt += 1) {
       try {
-        const response = await fetch(cloneFetchInput(input), init);
+        const response = responseWithProviderResponseLimit(
+          await fetch(cloneFetchInput(input), init),
+          maxResponseBytes,
+        );
         if (!isRetryableHttpStatus(response.status) || attempt >= maxRetries) return response;
 
         const delayMs = retryDelayMsForHeaders(response.headers, baseDelayMs);
@@ -68,6 +74,13 @@ function aiRequestRetryDelayMsFor(config: GitVibeConfig): number {
   );
 }
 
+function aiProviderResponseMaxBytesFor(config: GitVibeConfig): number {
+  return positiveInteger(
+    configNumber(config.ai?.budgets, "provider_response_max_bytes"),
+    DEFAULT_PROVIDER_RESPONSE_MAX_BYTES,
+  );
+}
+
 function isRetryableHttpStatus(status: number): boolean {
   return status === 408 || status === 409 || status === 429 || status >= 500;
 }
@@ -99,6 +112,55 @@ function cloneFetchInput(input: Parameters<typeof fetch>[0]): Parameters<typeof 
   return input instanceof Request ? input.clone() : input;
 }
 
+function responseWithProviderResponseLimit(response: Response, maxBytes: number): Response {
+  const contentLength = contentLengthBytes(response.headers);
+  if (contentLength !== undefined && contentLength > maxBytes) {
+    void discardResponse(response);
+    throw providerResponseTooLargeError(maxBytes, contentLength);
+  }
+  if (!response.body) return response;
+
+  // The AI SDK JSON handlers call response.text(); cap the stream before it can buffer without bound.
+  return new Response(response.body.pipeThrough(providerResponseLimitStream(maxBytes)), {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function providerResponseLimitStream(maxBytes: number): TransformStream<Uint8Array, Uint8Array> {
+  let receivedBytes = 0;
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      receivedBytes += chunk.byteLength;
+      if (receivedBytes > maxBytes) {
+        controller.error(providerResponseTooLargeError(maxBytes, receivedBytes));
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+  });
+}
+
+function contentLengthBytes(headers: Headers): number | undefined {
+  const value = headers.get("content-length");
+  if (!value) return undefined;
+  const bytes = Number.parseInt(value, 10);
+  return Number.isSafeInteger(bytes) && bytes >= 0 ? bytes : undefined;
+}
+
+function providerResponseTooLargeError(
+  maxBytes: number,
+  receivedBytes: number,
+): Error & { isRetryable: false } {
+  return Object.assign(
+    new Error(
+      `AI provider response exceeded maximum size of ${maxBytes} bytes after ${receivedBytes} bytes.`,
+    ),
+    { isRetryable: false as const },
+  );
+}
+
 async function discardResponse(response: Response): Promise<void> {
   try {
     await response.body?.cancel();
@@ -120,4 +182,9 @@ function configNumber(value: unknown, key: string): number | undefined {
 function nonNegativeInteger(value: number | undefined, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
   return Math.max(0, Math.floor(value as number));
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.floor(value as number));
 }

--- a/src/runner/ai-retry.ts
+++ b/src/runner/ai-retry.ts
@@ -1,6 +1,7 @@
 import { stringField } from "./ai-tool-logging.js";
 import type { StageLogger } from "./logging.js";
 import { summarizeError } from "./logging.js";
+import { positiveBudgetInteger } from "../shared/budgets.js";
 import type { GitVibeConfig } from "../shared/types.js";
 
 const DEFAULT_PROVIDER_RESPONSE_MAX_BYTES = 64 * 1024 * 1024;
@@ -15,11 +16,10 @@ export function createRetryingFetch(options: {
   return async (input, init) => {
     for (let attempt = 0; ; attempt += 1) {
       try {
-        const response = responseWithProviderResponseLimit(
-          await fetch(cloneFetchInput(input), init),
-          maxResponseBytes,
-        );
-        if (!isRetryableHttpStatus(response.status) || attempt >= maxRetries) return response;
+        const response = await fetch(cloneFetchInput(input), init);
+        if (!isRetryableHttpStatus(response.status) || attempt >= maxRetries) {
+          return responseWithProviderResponseLimit(response, maxResponseBytes);
+        }
 
         const delayMs = retryDelayMsForHeaders(response.headers, baseDelayMs);
         options.logger?.event("ai.http.retry", {
@@ -75,8 +75,9 @@ function aiRequestRetryDelayMsFor(config: GitVibeConfig): number {
 }
 
 function aiProviderResponseMaxBytesFor(config: GitVibeConfig): number {
-  return positiveInteger(
-    configNumber(config.ai?.budgets, "provider_response_max_bytes"),
+  return positiveBudgetInteger(
+    config,
+    "provider_response_max_bytes",
     DEFAULT_PROVIDER_RESPONSE_MAX_BYTES,
   );
 }
@@ -182,9 +183,4 @@ function configNumber(value: unknown, key: string): number | undefined {
 function nonNegativeInteger(value: number | undefined, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
   return Math.max(0, Math.floor(value as number));
-}
-
-function positiveInteger(value: number | undefined, fallback: number): number {
-  if (!Number.isFinite(value)) return fallback;
-  return Math.max(1, Math.floor(value as number));
 }

--- a/src/shared/github-app-permissions.ts
+++ b/src/shared/github-app-permissions.ts
@@ -99,7 +99,7 @@ export function permissionsForProfile(
     case "runner-workflow-write":
       return {
         actions: "write",
-        contents: "read",
+        contents: "write",
         discussions: "write",
         issues: "write",
         pull_requests: "write",

--- a/tests/ai-retry.test.mjs
+++ b/tests/ai-retry.test.mjs
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createRetryingFetch } from "../src/runner/ai-retry.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("AI provider response limits", () => {
+  it("rejects provider responses whose declared size exceeds the configured limit", async () => {
+    const logger = { event: vi.fn() };
+    const retryingFetch = createRetryingFetch({
+      config: config({ provider_response_max_bytes: 3, request_retry_delay_seconds: 0 }),
+      logger,
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new globalThis.Response("large", {
+        headers: { "content-length": "4" },
+        status: 200,
+      }),
+    );
+
+    await expect(retryingFetch("https://api.test/v1/chat/completions")).rejects.toThrow(
+      "AI provider response exceeded maximum size of 3 bytes after 4 bytes.",
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(logger.event).not.toHaveBeenCalledWith("ai.http.retry", expect.any(Object));
+  });
+
+  it("rejects chunked provider responses that cross the configured limit", async () => {
+    const retryingFetch = createRetryingFetch({
+      config: config({ provider_response_max_bytes: 3 }),
+    });
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new globalThis.Response("large", { status: 200 }));
+
+    const response = await retryingFetch("https://api.test/v1/chat/completions");
+
+    await expect(response.text()).rejects.toThrow(
+      "AI provider response exceeded maximum size of 3 bytes after 5 bytes.",
+    );
+  });
+});
+
+/** @param {Record<string, number>} budgets */
+function config(budgets) {
+  return { ai: { budgets } };
+}

--- a/tests/ai-retry.test.mjs
+++ b/tests/ai-retry.test.mjs
@@ -46,9 +46,59 @@ describe("AI provider response limits", () => {
       "AI provider response exceeded maximum size of 3 bytes after 5 bytes.",
     );
   });
+
+  it("retries declared oversized retryable responses before applying the limit", async () => {
+    const logger = { event: vi.fn() };
+    const retryingFetch = createRetryingFetch({
+      config: config({
+        provider_response_max_bytes: 3,
+        request_retry_attempts: 1,
+        request_retry_delay_seconds: 0,
+      }),
+      logger,
+    });
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new globalThis.Response("large", {
+          headers: { "content-length": "4" },
+          status: 500,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new globalThis.Response("ok", {
+          headers: { "content-length": "2" },
+          status: 200,
+        }),
+      );
+
+    const response = await retryingFetch("https://api.test/v1/chat/completions");
+
+    await expect(response.text()).resolves.toBe("ok");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(logger.event).toHaveBeenCalledWith(
+      "ai.http.retry",
+      expect.objectContaining({ attempt: 1, status: 500 }),
+    );
+  });
+
+  it("rejects invalid explicit provider response limits", () => {
+    expect(() =>
+      createRetryingFetch({
+        config: config({ provider_response_max_bytes: "3" }),
+      }),
+    ).toThrow("ai.budgets.provider_response_max_bytes must be a positive integer.");
+
+    expect(() =>
+      createRetryingFetch({
+        config: config({ provider_response_max_bytes: 0 }),
+      }),
+    ).toThrow("ai.budgets.provider_response_max_bytes must be a positive integer.");
+  });
 });
 
-/** @param {Record<string, number>} budgets */
+/** @param {Record<string, unknown>} budgets */
 function config(budgets) {
   return { ai: { budgets } };
 }

--- a/tests/github-app-auth.test.mjs
+++ b/tests/github-app-auth.test.mjs
@@ -46,7 +46,7 @@ describe("GitHub App installation token provider", () => {
       body: {
         permissions: {
           actions: "write",
-          contents: "read",
+          contents: "write",
           discussions: "write",
           issues: "write",
           pull_requests: "write",
@@ -244,7 +244,7 @@ describe("GitHub App permission profiles", () => {
     });
     expect(permissionsForProfile("runner-workflow-write")).toEqual({
       actions: "write",
-      contents: "read",
+      contents: "write",
       discussions: "write",
       issues: "write",
       pull_requests: "write",


### PR DESCRIPTION
## Summary

- Raises AI SDK dependency floors to pick up upstream provider fixes.
- Adds a 64 MiB default cap for AI provider HTTP responses, configurable with `ai.budgets.provider_response_max_bytes`.
- Adds regression coverage for declared and chunked oversized provider responses.
- Documents the provider response cap in the README.
- Bumps the root app package version to `4.1.1`; `git-vibe-setup` remains at `4.1.0` because this patch does not change the setup package.

## Why

GitHub code scanning flagged AI SDK/provider response handling issues. This keeps the dependency floor current and adds a GitVibe-side response limit so provider responses cannot be buffered without bound by downstream AI SDK JSON handlers.

## Validation

- `corepack pnpm check`
- Commit hook checks: lint-staged, workflow template contract, typecheck, coverage

## Notes

`dev` was merged with `origin/main` before opening this PR to avoid carrying the prior package-version downgrade into `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify the default 64 MiB cap on AI SDK provider HTTP responses and how to increase it for trusted providers via `ai.budgets.provider_response_max_bytes`.
* **New Features**
  * Enforced provider response size limits during fetch, including during streaming/body reads, with clear “maximum size” errors.
  * If a response is retryable and oversized, the retry flow occurs before enforcing the size limit.
* **Bug Fixes**
  * Adjusted GitHub app permission profile so `runner-workflow-write` now uses `contents: write`.
* **Chores**
  * Bumped version to 4.1.1 and updated dependency versions.
* **Tests**
  * Added/expanded tests for size limits, retry interactions, and invalid budget validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->