### PR TITLE
[codex] Validate PR review anchors before posting

### DIFF
--- a/src/runner/pr-review-anchors.ts
+++ b/src/runner/pr-review-anchors.ts
@@ -1,0 +1,182 @@
+import { paginatedGitHubRequest, splitRepository, type GitHubClient } from "../shared/github.js";
+import { summarizeError, type StageLogger } from "./logging.js";
+import type { PullRequestReviewComment } from "./pr-review-github.js";
+
+export interface ReviewFindingAnchorInput {
+  body: string;
+  reviewComment: PullRequestReviewComment;
+}
+
+export interface UnanchoredReviewFinding {
+  body: string;
+  line: number;
+  path: string;
+  reason: string;
+  startLine?: number;
+}
+
+interface PullRequestFilePatch {
+  filename?: unknown;
+  patch?: unknown;
+}
+
+interface FileAnchorIndex {
+  LEFT: Map<number, number>;
+  RIGHT: Map<number, number>;
+}
+
+const hunkHeaderPattern = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+export async function validateReviewFindingAnchors(options: {
+  client: GitHubClient;
+  findings: ReviewFindingAnchorInput[];
+  logger: StageLogger;
+  pullNumber: string;
+  repository: string;
+  token: string;
+}): Promise<{
+  comments: PullRequestReviewComment[];
+  unanchoredFindings: UnanchoredReviewFinding[];
+}> {
+  if (!options.findings.length) return { comments: [], unanchoredFindings: [] };
+
+  let index: Map<string, FileAnchorIndex>;
+  try {
+    index = reviewPatchIndex(
+      await pullRequestFilePatches({
+        client: options.client,
+        pullNumber: options.pullNumber,
+        repository: options.repository,
+        token: options.token,
+      }),
+    );
+  } catch (error) {
+    options.logger.event("github.pr.review.anchors.lookup.failed", {
+      comments: options.findings.length,
+      error: summarizeError(error),
+    });
+    return {
+      comments: [],
+      unanchoredFindings: options.findings.map((finding) =>
+        unanchoredReviewFinding(finding, "patch lookup failed"),
+      ),
+    };
+  }
+
+  const comments: PullRequestReviewComment[] = [];
+  const unanchoredFindings: UnanchoredReviewFinding[] = [];
+  let downgraded = 0;
+  for (const finding of options.findings) {
+    const comment = { ...finding.reviewComment };
+    if (!isReviewLine(index, comment)) {
+      unanchoredFindings.push(
+        unanchoredReviewFinding(finding, "line is not in the pull request diff"),
+      );
+      continue;
+    }
+    if (comment.start_line !== undefined && !isReviewRange(index, comment)) {
+      delete comment.start_line;
+      delete comment.start_side;
+      downgraded += 1;
+    }
+    comments.push(comment);
+  }
+
+  options.logger.event("github.pr.review.anchors.checked", {
+    comments: options.findings.length,
+    downgraded,
+    posted: comments.length,
+    unanchored: unanchoredFindings.length,
+  });
+  return { comments, unanchoredFindings };
+}
+
+async function pullRequestFilePatches(options: {
+  client: GitHubClient;
+  pullNumber: string;
+  repository: string;
+  token: string;
+}): Promise<PullRequestFilePatch[]> {
+  const { owner, repo } = splitRepository(options.repository);
+  return paginatedGitHubRequest<PullRequestFilePatch>(options.client, {
+    method: "GET",
+    path: `/repos/${owner}/${repo}/pulls/${options.pullNumber}/files`,
+    token: options.token,
+  });
+}
+
+function reviewPatchIndex(files: PullRequestFilePatch[]): Map<string, FileAnchorIndex> {
+  const index = new Map<string, FileAnchorIndex>();
+  for (const file of files) {
+    if (typeof file.filename !== "string" || typeof file.patch !== "string") continue;
+    index.set(file.filename, fileAnchorIndex(file.patch));
+  }
+  return index;
+}
+
+function fileAnchorIndex(patch: string): FileAnchorIndex {
+  const file: FileAnchorIndex = { LEFT: new Map(), RIGHT: new Map() };
+  let hunk = -1;
+  let oldLine = 0;
+  let newLine = 0;
+  for (const line of patch.split(/\r?\n/)) {
+    const header = line.match(hunkHeaderPattern);
+    if (header) {
+      hunk += 1;
+      oldLine = Number(header[1]);
+      newLine = Number(header[2]);
+      continue;
+    }
+    if (hunk < 0 || line.startsWith("\\")) continue;
+    if (line.startsWith(" ")) {
+      file.LEFT.set(oldLine, hunk);
+      file.RIGHT.set(newLine, hunk);
+      oldLine += 1;
+      newLine += 1;
+    } else if (line.startsWith("+")) {
+      file.RIGHT.set(newLine, hunk);
+      newLine += 1;
+    } else if (line.startsWith("-")) {
+      file.LEFT.set(oldLine, hunk);
+      oldLine += 1;
+    }
+  }
+  return file;
+}
+
+function isReviewLine(
+  index: Map<string, FileAnchorIndex>,
+  comment: PullRequestReviewComment,
+): boolean {
+  return sideHunks(index, comment)?.has(comment.line) || false;
+}
+
+function isReviewRange(
+  index: Map<string, FileAnchorIndex>,
+  comment: PullRequestReviewComment,
+): boolean {
+  if (comment.start_line === undefined) return true;
+  const hunks = sideHunks(index, comment);
+  const startHunk = hunks?.get(comment.start_line);
+  return startHunk !== undefined && startHunk === hunks?.get(comment.line);
+}
+
+function sideHunks(
+  index: Map<string, FileAnchorIndex>,
+  comment: PullRequestReviewComment,
+): Map<number, number> | undefined {
+  return index.get(comment.path)?.[comment.side];
+}
+
+function unanchoredReviewFinding(
+  finding: ReviewFindingAnchorInput,
+  reason: string,
+): UnanchoredReviewFinding {
+  return {
+    body: finding.body,
+    line: finding.reviewComment.line,
+    path: finding.reviewComment.path,
+    reason,
+    startLine: finding.reviewComment.start_line,
+  };
+}

--- a/src/runner/pr-review-publishing.ts
+++ b/src/runner/pr-review-publishing.ts
@@ -3,6 +3,7 @@ import { GitHubClient, isGitHubGraphQLForbiddenError, splitRepository } from "..
 import { workflowRunIdFromUrl } from "../shared/status-comments.js";
 import type { ContextPacket, JsonObject, RunnerOptions } from "../shared/types.js";
 import type { StageLogger } from "./logging.js";
+import { validateReviewFindingAnchors, type UnanchoredReviewFinding } from "./pr-review-anchors.js";
 import {
   createPullRequestReview,
   type PullRequestReviewComment,
@@ -49,11 +50,20 @@ export async function publishPullRequestReviewResult(options: {
   const newFindings = shouldReconcileReviewFindings(options.parsedOutput)
     ? (await reconcileReviewFindings({ ...options, findings })).newFindings
     : findings;
-  const comments = newFindings.map((finding) => finding.reviewComment);
+  const validated = await validateReviewFindingAnchors({
+    client: options.client,
+    findings: newFindings,
+    logger: options.logger,
+    pullNumber: options.context.artifact.number,
+    repository: options.runner.repository,
+    token: options.runner.token,
+  });
+  const comments = validated.comments;
   const body = pullRequestReviewBody({
     comments,
     output: options.parsedOutput,
     stageResultBody: options.stageResultBody,
+    unanchoredFindings: validated.unanchoredFindings,
     workflowRunUrl: options.runner.workflowRunUrl,
   });
   const existingReview = await editableReviewForStageResult({ ...options, comments });
@@ -571,12 +581,17 @@ function pullRequestReviewBody(options: {
   comments: PullRequestReviewComment[];
   output: JsonObject;
   stageResultBody: string;
+  unanchoredFindings: UnanchoredReviewFinding[];
   workflowRunUrl?: string;
 }): string {
   const findings = stringItems(options.output.findings);
   return cleanLines([
     ...options.stageResultBody.split(/\r?\n/),
-    ...reviewDetailsSection({ comments: options.comments, findings }),
+    ...reviewDetailsSection({
+      comments: options.comments,
+      findings,
+      unanchoredFindings: options.unanchoredFindings,
+    }),
     ...fallbackWorkflowRunSection(options.stageResultBody, options.workflowRunUrl),
   ]).join("\n");
 }
@@ -584,12 +599,16 @@ function pullRequestReviewBody(options: {
 function reviewDetailsSection(options: {
   comments: PullRequestReviewComment[];
   findings: string[];
+  unanchoredFindings: UnanchoredReviewFinding[];
 }): string[] {
-  if (!options.comments.length && !options.findings.length) return [];
+  if (!options.comments.length && !options.findings.length && !options.unanchoredFindings.length) {
+    return [];
+  }
   return [
     "",
     `**Inline comments:** ${options.comments.length}`,
     ...findingsSection(options.findings),
+    ...unanchoredFindingsSection(options.unanchoredFindings),
   ];
 }
 
@@ -600,6 +619,22 @@ function findingsSection(findings: string[]): string[] {
     "### Required Fixes",
     ...findings.map((finding, index) => `${index + 1}. ${finding}`),
   ];
+}
+
+function unanchoredFindingsSection(findings: UnanchoredReviewFinding[]): string[] {
+  if (!findings.length) return [];
+  return [
+    "",
+    "### Unanchored Inline Findings",
+    ...findings.flatMap((finding, index) => [
+      `${index + 1}. \`${finding.path}:${lineRange(finding)}\` (${finding.reason})`,
+      ...finding.body.split(/\r?\n/).map((line) => `   ${line}`),
+    ]),
+  ];
+}
+
+function lineRange(finding: UnanchoredReviewFinding): string {
+  return finding.startLine ? `${finding.startLine}-${finding.line}` : String(finding.line);
 }
 
 function fallbackWorkflowRunSection(body: string, url: string | undefined): string[] {

--- a/tests/pr-review-anchors.test.mjs
+++ b/tests/pr-review-anchors.test.mjs
@@ -1,0 +1,283 @@
+import { describe, expect, it, vi } from "vitest";
+import { publishPullRequestReviewResult } from "../src/runner/pr-review-publishing.ts";
+
+/**
+ * @typedef {import("../src/shared/github.ts").GitHubClient & { graphql: any; request: any }} MockGitHubClient
+ * @typedef {import("../src/shared/types.ts").ContextPacket} ContextPacket
+ * @typedef {import("../src/shared/types.ts").RunnerOptions} RunnerOptions
+ * @typedef {import("../src/runner/pr-review-github.ts").PullRequestReviewComment} PullRequestReviewComment
+ */
+
+describe("pull request review anchor validation ranges", () => {
+  it("downgrades ranges that start before the modified diff hunk", async () => {
+    const client = createClient({ files: pr35Files() });
+    const logger = createLogger();
+
+    await publishPullRequestReviewResult({
+      client,
+      context: context(),
+      logger,
+      parsedOutput: {
+        ...output(),
+        inline_comments: [
+          { body: "Server startup gate.", line: 428, path: "cmd/server/main.go", start_line: 422 },
+          {
+            body: "Demo startup gate.",
+            line: 405,
+            path: "cmd/demo-server/main.go",
+            start_line: 399,
+          },
+          {
+            body: "Fact status guard.",
+            line: 85,
+            path: "internal/service/recallservice/community_expansion.go",
+            start_line: 82,
+          },
+          {
+            body: "Claim status guard.",
+            line: 154,
+            path: "internal/service/recallservice/community_expansion.go",
+            start_line: 151,
+          },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+      stageResultBody: "Review summary.",
+    });
+
+    const comments = reviewRequest(client).body.comments || [];
+    expect(comments).toHaveLength(4);
+    expect(comments.find((comment) => comment.path === "cmd/server/main.go")).not.toHaveProperty(
+      "start_line",
+    );
+    expect(
+      comments.find((comment) => comment.path === "cmd/demo-server/main.go"),
+    ).not.toHaveProperty("start_line");
+    expect(
+      comments.find(
+        (comment) =>
+          comment.path === "internal/service/recallservice/community_expansion.go" &&
+          comment.line === 85,
+      ),
+    ).toMatchObject({ start_line: 82 });
+    expect(logger.event).toHaveBeenCalledWith("github.pr.review.anchors.checked", {
+      comments: 4,
+      downgraded: 2,
+      posted: 4,
+      unanchored: 0,
+    });
+  });
+});
+
+describe("pull request review anchor validation unanchored lines", () => {
+  it("keeps left-side comments on deleted lines", async () => {
+    const client = createClient({
+      files: [
+        {
+          filename: "src/app.ts",
+          patch: "@@ -10,3 +10,2 @@\n keep\n-removed\n keep",
+        },
+      ],
+    });
+
+    await publishPullRequestReviewResult({
+      client,
+      context: context(),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        inline_comments: [
+          { body: "Deleted-line finding.", line: 11, path: "src/app.ts", side: "LEFT" },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+      stageResultBody: "Review summary.",
+    });
+
+    expect(reviewRequest(client).body.comments).toEqual([
+      expect.objectContaining({ line: 11, path: "src/app.ts", side: "LEFT" }),
+    ]);
+  });
+
+  it("moves comments with unresolved lines into the review body", async () => {
+    const client = createClient({
+      files: [
+        {
+          filename: "src/app.ts",
+          patch: "@@ -40,3 +40,4 @@\n line 40\n line 41\n+line 42\n line 43",
+        },
+      ],
+    });
+
+    await publishPullRequestReviewResult({
+      client,
+      context: context(),
+      logger: createLogger(),
+      parsedOutput: {
+        ...output(),
+        inline_comments: [
+          { body: "Anchored finding.", line: 42, path: "src/app.ts" },
+          { body: "Unanchored finding.", line: 99, path: "src/app.ts" },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+      stageResultBody: "Review summary.",
+    });
+
+    const review = reviewRequest(client);
+    expect(review.body.comments).toHaveLength(1);
+    expect(review.body.body).toContain("### Unanchored Inline Findings");
+    expect(review.body.body).toContain("`src/app.ts:99` (line is not in the pull request diff)");
+    expect(review.body.body).toContain("Unanchored finding.");
+  });
+});
+
+describe("pull request review anchor validation lookup failures", () => {
+  it("posts a top-level review when patch lookup fails", async () => {
+    const client = createClient({ filesError: new Error("files unavailable") });
+    const logger = createLogger();
+
+    await publishPullRequestReviewResult({
+      client,
+      context: context(),
+      logger,
+      parsedOutput: {
+        ...output(),
+        inline_comments: [
+          { body: "Could not validate this anchor.", line: 42, path: "src/app.ts" },
+        ],
+        next_state: "changes-required",
+        stage: "review-matrix",
+      },
+      runner: runner(),
+      stageResultBody: "Review summary.",
+    });
+
+    const review = reviewRequest(client);
+    expect(review.body.comments).toBeUndefined();
+    expect(review.body.body).toContain("`src/app.ts:42` (patch lookup failed)");
+    expect(logger.event).toHaveBeenCalledWith("github.pr.review.anchors.lookup.failed", {
+      comments: 1,
+      error: expect.stringContaining("files unavailable"),
+    });
+  });
+});
+
+function pr35Files() {
+  return [
+    {
+      filename: "cmd/server/main.go",
+      patch:
+        '@@ -423,6 +425,8 @@ func main() {\n \tcommunityProbeCancel()\n \tif communityAvailable {\n \t\tcommunityDetectRegistrySvc = communityservice.NewLeidenService(pgDB.GetDB(), neo4jClient, &cfg, slog.Default())\n+\t} else {\n+\t\tslog.Default().Warn("community scheduler: GDS unavailable, scheduler not started")\n \t}',
+    },
+    {
+      filename: "cmd/demo-server/main.go",
+      patch:
+        '@@ -400,6 +402,8 @@ func main() {\n \tcommunityProbeCancel()\n \tif communityAvailable {\n \t\tcommunityDetectRegistrySvc = communityservice.NewLeidenService(pgDB.GetDB(), neo4jClient, &cfg, slog.Default())\n+\t} else {\n+\t\tslog.Default().Warn("community scheduler: GDS unavailable, scheduler not started")\n \t}',
+    },
+    {
+      filename: "internal/service/recallservice/community_expansion.go",
+      patch: `@@ -0,0 +1,160 @@\n${Array.from({ length: 160 }, (_, index) => `+line ${index + 1}`).join("\n")}`,
+    },
+  ];
+}
+
+/** @returns {Record<string, unknown>} */
+function output() {
+  return {
+    assumptions: [],
+    findings: [],
+    next_state: "ready-for-materialization",
+    references: [],
+    stage: "materialize",
+    status: "completed",
+    summary: "Result summary.",
+  };
+}
+
+/** @returns {ContextPacket} */
+function context() {
+  return /** @type {ContextPacket} */ ({
+    artifact: {
+      body: "Body",
+      number: "12",
+      title: "Title",
+      type: "pull-request",
+      url: "https://github.com/example/repo/pulls/12",
+    },
+    generatedAt: "2026-01-01T00:00:00Z",
+    repository: "example/repo",
+    timeline: [],
+  });
+}
+
+/** @returns {RunnerOptions} */
+function runner() {
+  return /** @type {RunnerOptions} */ ({
+    cwd: "/repo",
+    dryRun: false,
+    issueNumber: "12",
+    maxTurns: 2,
+    prNumber: "12",
+    repository: "example/repo",
+    stage: "review-matrix",
+    stageTimeoutMinutes: 1,
+    token: "token",
+  });
+}
+
+/**
+ * @param {{ files?: unknown[]; filesError?: Error }} [options]
+ * @returns {MockGitHubClient}
+ */
+function createClient(options = {}) {
+  return /** @type {MockGitHubClient} */ ({
+    apiBaseUrl: "https://api.github.test",
+    graphql: vi.fn(async () => ({})),
+    request: vi.fn(
+      /**
+       * @param {any} request
+       */
+      async (request) => {
+        if (request.path.startsWith("/repos/example/repo/pulls/12/files")) {
+          if (options.filesError) throw options.filesError;
+          return options.files || [];
+        }
+        return {};
+      },
+    ),
+    retryBaseDelayMs: 0,
+  });
+}
+
+function createLogger() {
+  return {
+    event: vi.fn(),
+  };
+}
+
+/**
+ * @param {MockGitHubClient} client
+ * @returns {{ body: { body: string; comments?: PullRequestReviewComment[] } }}
+ */
+function reviewRequest(client) {
+  return client.request.mock.calls
+    .map(
+      /**
+       * @param {any[]} call
+       */
+      (call) => call[0],
+    )
+    .find(
+      /**
+       * @param {any} request
+       */
+      (request) => request.path.endsWith("/pulls/12/reviews"),
+    );
+}

--- a/tests/pr-review-publishing.test.mjs
+++ b/tests/pr-review-publishing.test.mjs
@@ -635,7 +635,7 @@ function runner(overrides = {}) {
 }
 
 /**
- * @param {{ login?: string; unresolvedReviewLineError?: boolean; userLookupError?: boolean }} [options]
+ * @param {{ files?: unknown[]; login?: string; unresolvedReviewLineError?: boolean; userLookupError?: boolean }} [options]
  * @returns {MockGitHubClient}
  */
 function createClient(options = {}) {
@@ -644,6 +644,17 @@ function createClient(options = {}) {
     apiBaseUrl: "https://api.github.test",
     graphql: vi.fn(async () => ({})),
     request: vi.fn(async (request) => {
+      if (request.path.startsWith("/repos/example/repo/pulls/12/files")) {
+        return (
+          options.files || [
+            {
+              filename: "src/app.ts",
+              patch:
+                "@@ -40,12 +40,12 @@\n line 40\n line 41\n line 42\n line 43\n line 44\n line 45\n line 46\n line 47\n line 48\n line 49\n line 50\n line 51",
+            },
+          ]
+        );
+      }
       if (
         options.unresolvedReviewLineError &&
         !rejectedInlineReview &&


### PR DESCRIPTION
## Summary

- Add deterministic validation for generated PR review inline-comment anchors before creating a GitHub review.
- Downgrade invalid multi-line ranges to single-line comments when the target line is still anchorable.
- Move unresolvable inline findings into the top-level review body instead of failing the workflow.
- Cover the PR #35 hunk shape, deleted-line LEFT comments, unresolved lines, and patch lookup failures.

## Root Cause

GitHub rejects the entire `POST /pulls/{pull_number}/reviews` request when any inline comment line or range cannot be resolved in the current PR diff. GitVibe previously validated only basic payload shape, so one AI-generated bad `start_line` could fail the whole review job with a 422.

## Validation

- `corepack pnpm check`
- Commit hook: Prettier, ESLint, workflow-template-contract, typecheck, coverage

## Notes

- Created from `dev` to `main` as ready for review.
- Current compare shows `dev` is 1 commit ahead of `main` and 1 commit behind `main`; update `dev` before merge if the branch protection requires it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for PR review comments to ensure they apply to actual code changes in the diff.
  * Unanchored review findings that don't match the diff are now included in the review body with clear messaging.
  * Review validation failures are now reported transparently in the review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->